### PR TITLE
Coap service security fixes

### DIFF
--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -205,7 +205,7 @@ static int simple_cookie_check(void *ctx,
 /**** Key export function ****/
 
 static int export_key_block(void *ctx,
-                            const unsigned char *kb, const unsigned char *mk,
+                            const unsigned char *mk, const unsigned char *kb,
                             size_t maclen, size_t keylen, size_t ivlen)
 {
     key_block_t *p_key_block = (key_block_t *)ctx;
@@ -413,6 +413,9 @@ int coap_security_handler_connect_non_blocking(coap_security_t *sec, bool is_ser
                                   simple_cookie_check,
                                   &sec->_cookie);
 
+    mbedtls_ssl_conf_min_version(&sec->_conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MAJOR_VERSION_3);
+    mbedtls_ssl_conf_max_version(&sec->_conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MAJOR_VERSION_3);
+	
     sec->_is_started = true;
 
     int ret = mbedtls_ssl_handshake_step( &sec->_ssl );

--- a/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -29,6 +29,13 @@ int mbedtls_ssl_close_notify( mbedtls_ssl_context *a )
 void mbedtls_ssl_init( mbedtls_ssl_context *a ){
 
 }
+void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int minor ){
+
+}
+
+void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor ){
+    
+}
 
 void mbedtls_ssl_config_init( mbedtls_ssl_config *a ){
 


### PR DESCRIPTION
Added initialisations for mbed TLS startup
Fix keyblock export

@AnttiKauppila @terhei @deepakvenugopal  please check
