### PR TITLE
fixed valgrind errors

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -596,8 +596,7 @@ void connection_handler_destroy(coap_conn_handler_t *handler)
             }
         }
         int_socket_delete(handler->socket);
-        handler->socket = NULL;
-        ns_dyn_mem_free(handler);
+
     }
 }
 


### PR DESCRIPTION
removed this free because the function int_socket_delete already frees the pointer passed to it.

@terhei @artokin @mikter please review