### PR TITLE
Limit the number of mbed_ssl_read() in while loop.

### DIFF
--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -498,12 +498,15 @@ int coap_security_send_close_alert(coap_security_t *sec)
 
 int coap_security_handler_read(coap_security_t *sec, unsigned char* buffer, size_t len){
     int ret=-1;
+    int max_loops = 100;
 
     if( sec && buffer ){
         memset( buffer, 0, len );
-        do ret = mbedtls_ssl_read( &sec->_ssl, buffer, len );
-        while( ret == MBEDTLS_ERR_SSL_WANT_READ ||
-               ret == MBEDTLS_ERR_SSL_WANT_WRITE );
+        do {
+            ret = mbedtls_ssl_read( &sec->_ssl, buffer, len );
+        } while( (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+                  ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+                && --max_loops);
     }
     return ret; //bytes read
 }


### PR DESCRIPTION
@AnttiKauppila 

This do-while loop blocks the Thread testing, as there is no mechanism for it to stop. This happens when we try to stop the device.
