### PR TITLE
Fixes coap-service for development head of mbed TLS

### DIFF
--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -8,6 +8,7 @@
 
 #include "mbedtls/sha256.h"
 #include "mbedtls/error.h"
+#include "mbedtls/platform.h"
 #include "mbedtls/ssl_cookie.h"
 #include "mbedtls/entropy_poll.h"
 #include "mbedtls/ssl.h"

--- a/source/include/coap_security_handler.h
+++ b/source/include/coap_security_handler.h
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include "mbedtls/platform.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/entropy.h"


### PR DESCRIPTION
This change allows the mbed TLS type mbedtls_timer_t to be defined, required
for the upstream version of mbed TLS (> version 2.2.1).

Without this change, coap-service shouldn't build with the development head of mbed TLS.