### PR TITLE
Update content_type to sn_coap_content_format_e

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -119,11 +119,11 @@ typedef int coap_service_security_done_cb(int8_t service_id, uint8_t address[sta
  * \param listen_port        Port that Application wants to use for communicate with coap server.
  * \param service_options    Options of the current service.
  * \param *start_ptr         Callback to inform security handling is started and to fetch device password.
- * \param *security_done_cb  Callback to inform security handling is done.
+ * \param *coap_security_done_cb  Callback to inform security handling is done.
  *
  *  \return service_id / -1 for failure
  */
-extern int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options, coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *security_done_cb);
+extern int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options, coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *coap_security_done_cb);
 
 /**
  * \brief Service delete
@@ -245,7 +245,7 @@ extern int8_t coap_service_unregister_uri(int8_t service_id, const char *uri);
  * \return msg_id               Id number of the current message.
  */
 extern uint16_t coap_service_request_send(int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16], uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri,
-                                  uint8_t cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_service_response_recv *request_response_cb);
+        sn_coap_content_format_e cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_service_response_recv *request_response_cb);
 
 /**
  * \brief Sends CoAP service response
@@ -260,7 +260,7 @@ extern uint16_t coap_service_request_send(int8_t service_id, uint8_t options, co
  * \return -1              For failure
  *-         0              For success
  */
-extern int8_t coap_service_response_send(int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, int32_t content_type, const uint8_t *payload_ptr,uint16_t payload_len);
+extern int8_t coap_service_response_send(int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, sn_coap_content_format_e content_type, const uint8_t *payload_ptr,uint16_t payload_len);
 
 extern int8_t coap_service_set_handshake_timeout(int8_t service_id, uint32_t min, uint32_t max);
 #ifdef __cplusplus

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -317,6 +317,7 @@ static int send_to_socket(int8_t socket_id, uint8_t *address_ptr, uint16_t port,
 
 static int receive_from_socket(int8_t socket_id, unsigned char *buf, size_t len)
 {
+    (void)len;
     internal_socket_t *sock = int_socket_find_by_socket_id(socket_id);
     if( sock->data && sock->data_len > 0 ){
         memcpy( buf, sock->data, sock->data_len );

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -248,7 +248,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
 
 uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                    uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri,
-                                   uint8_t cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb)
+                                   sn_coap_content_format_e cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb)
 {
     coap_transaction_t *transaction_ptr;
     sn_coap_hdr_s request;
@@ -280,7 +280,7 @@ uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t se
     request.msg_code = msg_code;
     request.uri_path_ptr = (uint8_t *)uri;
     request.uri_path_len = strlen(uri);
-    coap_service_build_content_format(&request, (sn_coap_content_format_e)cont_type);
+    coap_service_build_content_format(&request, cont_type);
 
     do{
         randLIB_get_n_bytes_random(token,4);
@@ -313,7 +313,7 @@ uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t se
 }
 
 //TODO: refactor this to use nsdl
-int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, int32_t content_type, const uint8_t *payload_ptr, uint16_t payload_len)
+int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, sn_coap_content_format_e content_type, const uint8_t *payload_ptr, uint16_t payload_len)
 {
     coap_transaction_t *transaction_ptr;
     sn_coap_hdr_s *response;
@@ -321,6 +321,7 @@ int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t ser
     uint16_t data_len;
     uint8_t *data_ptr;
     (void) options;
+    (void)service_id;
 
     tr_debug("Service %d, send CoAP response", service_id);
     if (!request_ptr || !handle) {
@@ -345,7 +346,7 @@ int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t ser
     }
     response->payload_len = payload_len;
     response->payload_ptr = (uint8_t *) payload_ptr;  // Cast away const and trust that nsdl doesn't modify...
-    coap_service_build_content_format(response, (sn_coap_content_format_e)content_type);
+    coap_service_build_content_format(response, content_type);
 
     data_len = sn_coap_builder_calc_needed_packet_data_size(response);
     data_ptr = own_alloc(data_len);

--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -26,7 +26,7 @@ const int ECJPAKE_SUITES[] = {
 };
 #endif
 
-const static int PSK_SUITES[] = {
+static const int PSK_SUITES[] = {
     MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256,
     MBEDTLS_TLS_PSK_WITH_AES_256_CCM_8,
     MBEDTLS_TLS_PSK_WITH_AES_128_CCM_8,
@@ -204,7 +204,7 @@ static int simple_cookie_check(void *ctx,
 }
 
 /**** Key export function ****/
-
+#if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
 static int export_key_block(void *ctx,
                             const unsigned char *mk, const unsigned char *kb,
                             size_t maclen, size_t keylen, size_t ivlen)
@@ -224,6 +224,7 @@ static int export_key_block(void *ctx,
     memcpy(p_key_block->value, kb /* + (2 * maclen)*/, (2 * keylen) + (2 * ivlen));
     return 0;
 }
+#endif
 
 int coap_security_handler_configure_keys( coap_security_t *sec, coap_security_keys_t keys )
 {
@@ -559,6 +560,7 @@ int f_recv(void *ctx, unsigned char *buf, size_t len){
 int entropy_poll( void *ctx, unsigned char *output, size_t len,
                            size_t *olen )
 {
+    (void)ctx;
     //TODO: change to more secure random
     randLIB_seed_random();
     char *c = (char*)ns_dyn_mem_temporary_alloc(len);

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -73,11 +73,11 @@ extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle,
                                                          uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *));
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
-                                                      uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, uint8_t cont_type,
+                                                      uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,
                                                       const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb);
 
 extern int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code,
-                                                     int32_t content_type, const uint8_t *payload_ptr, uint16_t payload_len);
+        sn_coap_content_format_e content_type, const uint8_t *payload_ptr, uint16_t payload_len);
 
 extern int8_t coap_message_handler_exec(coap_msg_handler_t *handle, uint32_t current_time);
 

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -39,15 +39,14 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
     return coap_message_handler_stub.int16_value;
 }
 
-uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
-                                                      uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, uint8_t cont_type,
-                                                      const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb)
+uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, 
+    const uint8_t destination_addr[static 16], uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, 
+    const char *uri, sn_coap_content_format_e cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb)
 {
     return coap_message_handler_stub.uint16_value;
 }
 
-int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code,
-                                                     int32_t content_type, const uint8_t *payload_ptr, uint16_t payload_len)
+int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr,  sn_coap_msg_code_e message_code,sn_coap_content_format_e content_type, const uint8_t *payload_ptr, uint16_t payload_len)
 {
     return coap_message_handler_stub.int8_value;
 }
@@ -56,5 +55,4 @@ int8_t coap_message_handler_exec(coap_msg_handler_t *handle, uint32_t current_ti
 {
     return coap_message_handler_stub.int8_value;
 }
-
 

--- a/test/coap-service/unittest/stub/coap_service_api_stub.c
+++ b/test/coap-service/unittest/stub/coap_service_api_stub.c
@@ -19,7 +19,7 @@
 #include "net_interface.h"
 
 int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options,
-                                 coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *security_done_cb)
+                                 coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *coap_security_done_cb)
 {
     return 0;
 }
@@ -48,12 +48,13 @@ int8_t coap_service_unregister_uri(int8_t service_id, const char *uri)
     return 0;
 }
 
-uint16_t coap_service_request_send(int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16], uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri,
-                                  uint8_t cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_message_handler_response_recv *request_response_cb){
+uint16_t coap_service_request_send(int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16], uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type, const uint8_t *payload_ptr, uint16_t payload_len, coap_service_response_recv *request_response_cb)
+{
     return 0;
 }
 
-int8_t coap_service_response_send(int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, int32_t content_type, const uint8_t *payload_ptr,uint16_t payload_len){
+int8_t coap_service_response_send(int8_t service_id, uint8_t options, sn_coap_hdr_s *request_ptr, sn_coap_msg_code_e message_code, sn_coap_content_format_e content_type, const uint8_t *payload_ptr,uint16_t payload_len)
+{
     return 0;
 }
 


### PR DESCRIPTION
-Update content_type to be sn_coap_content_format_e instead of uint8_t to avoid type conversion (bugs).
-Fix compiler warnings