### PR TITLE
Fix unittests

### DIFF
--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -174,7 +174,7 @@ static void service_event_handler(arm_event_s *event)
 static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr)
 {
     coap_service_t *this;
-    if( !coap_message ){
+    if (!coap_message || !transaction_ptr) {
         return -1;
     }
 

--- a/test/coap-service/unittest/coap_message_handler/Makefile
+++ b/test/coap-service/unittest/coap_message_handler/Makefile
@@ -17,6 +17,7 @@ TEST_SRC_FILES = \
 	../stub/nsdynmemLIB_stub.c \
 	../stub/ns_list_stub.c \
 	../stub/randLIB_stub.c \
+	../stub/coap_service_api_stub.c
 
 include ../MakefileWorker.mk
 

--- a/test/coap-service/unittest/coap_service_api/Makefile
+++ b/test/coap-service/unittest/coap_service_api/Makefile
@@ -17,6 +17,7 @@ TEST_SRC_FILES = \
 	../stub/eventOS_event_stub.c \
 	../stub/coap_connection_handler_stub.c \
 	../stub/coap_message_handler_stub.c \
+	../stub/common_functions_stub.c
 
 include ../MakefileWorker.mk
 

--- a/test/coap-service/unittest/stub/coap_service_api_stub.c
+++ b/test/coap-service/unittest/stub/coap_service_api_stub.c
@@ -62,3 +62,8 @@ uint32_t coap_service_get_internal_timer_ticks(void)
 {
     return 1;
 }
+
+uint16_t coap_service_id_find_by_socket(int8_t socket_id)
+{
+    return 1;
+}

--- a/test/coap-service/unittest/stub/common_functions_stub.c
+++ b/test/coap-service/unittest/stub/common_functions_stub.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "ns_types.h"
+
+uint16_t common_read_16_bit(const uint8_t data_buf[__static 2])
+{
+    return 0;
+}


### PR DESCRIPTION
Adding missing stubs, and added check for nullpointer to coap message
process callback.

@artokin 