### PR TITLE
Switch out coap code if no entropy

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -2,6 +2,10 @@
  * Copyright (c) 2015-2016 ARM Limited. All Rights Reserved.
  */
 
+#include "mbedtls/platform.h"
+
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT) || defined(MBEDTLS_TEST_NULL_ENTROPY)
+
 #include <string.h>
 #include "coap_connection_handler.h"
 #include "coap_security_handler.h"
@@ -806,3 +810,5 @@ void coap_connection_handler_exec(uint32_t time)
         }
     }
 }
+
+#endif /* defined(MBEDTLS_ENTROPY_HARDWARE_ALT) || defined(MBEDTLS_TEST_NULL_ENTROPY) */

--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -2,6 +2,10 @@
  * Copyright (c) 2015-2016 ARM Limited. All Rights Reserved.
  */
 
+#include "mbedtls/platform.h"
+
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT) || defined(MBEDTLS_TEST_NULL_ENTROPY)
+
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
@@ -579,3 +583,5 @@ int entropy_poll( void *ctx, unsigned char *output, size_t len,
     ns_dyn_mem_free(c);
     return( 0 );
 }
+
+#endif /* defined(MBEDTLS_ENTROPY_HARDWARE_ALT) || defined(MBEDTLS_TEST_NULL_ENTROPY) */


### PR DESCRIPTION
Switch out the coap code that depends on TLS if there is no entropy source present. This allow configurations of Nanostack which don't use security to work without an entropy source.