### PR TITLE
Allow build without SSL

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -224,7 +224,11 @@ static internal_socket_t *int_socket_create(uint16_t listen_port, bool use_ephem
         if( !is_secure ){
             this->listen_socket = socket_open(SOCKET_UDP, listen_port, recv_sckt_msg);
         }else{
+#ifdef COAP_SECURITY_AVAILABLE
             this->listen_socket = socket_open(SOCKET_UDP, listen_port, secure_recv_sckt_msg);
+#else
+            tr_err("Secure CoAP unavailable - SSL library not configured, possibly due to lack of entropy source");
+#endif
         }
         // Socket create failed
         if(this->listen_socket < 0){

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -64,6 +64,9 @@ typedef struct secure_session {
     coap_security_t *sec_handler; //owned
     internal_socket_t *parent; //not owned
 
+    uint8_t  remote_address[16];
+    uint16_t remote_port;
+
     secure_timer_t timer;
 
     session_state_t session_state;
@@ -72,7 +75,7 @@ typedef struct secure_session {
 } secure_session_t;
 
 static NS_LIST_DEFINE(secure_session_list, secure_session_t, link);
-static int send_to_socket(int8_t socket_id, const uint8_t *address_ptr, uint16_t port, const uint8_t source_addr[static 16], const void *buf, size_t len);
+static int send_to_socket(int8_t socket_id, void *handle, const void *buf, size_t len);
 static int receive_from_socket(int8_t socket_id, unsigned char *buf, size_t len);
 static void start_timer(int8_t timer_id, uint32_t int_ms, uint32_t fin_ms);
 static int timer_status(int8_t timer_id);
@@ -146,8 +149,10 @@ static secure_session_t *secure_session_create(internal_socket_t *parent, const 
         timer_id++;
     }
     this->timer.id = timer_id;
+    memcpy(this->remote_address, address_ptr, 16);
+    this->remote_port = port;
 
-    this->sec_handler = coap_security_create(parent->listen_socket, this->timer.id, address_ptr, port, ECJPAKE,
+    this->sec_handler = coap_security_create(parent->listen_socket, this->timer.id, this, ECJPAKE,
                                                &send_to_socket, &receive_from_socket, &start_timer, &timer_status);
     if( !this->sec_handler ){
         ns_dyn_mem_free(this);
@@ -178,8 +183,8 @@ static secure_session_t *secure_session_find(internal_socket_t *parent, const ui
     secure_session_t *this = NULL;
     ns_list_foreach(secure_session_t, cur_ptr, &secure_session_list) {
         if( cur_ptr->sec_handler ){
-            if (cur_ptr->parent == parent && cur_ptr->sec_handler->_remote_port == port &&
-                memcmp(cur_ptr->sec_handler->_remote_address, address_ptr, 16) == 0) {
+            if (cur_ptr->parent == parent && cur_ptr->remote_port == port &&
+                memcmp(cur_ptr->remote_address, address_ptr, 16) == 0) {
                 this = cur_ptr;
     //            hack_save_remote_address(address_ptr, port);
                 break;
@@ -329,15 +334,16 @@ static int8_t send_to_real_socket(int8_t socket_id, const ns_address_t *address,
     return socket_sendmsg(socket_id, &msghdr, 0);
 }
 
-static int send_to_socket(int8_t socket_id, const uint8_t *address_ptr, uint16_t port, const uint8_t source_addr[static 16], const void *buf, size_t len)
+static int send_to_socket(int8_t socket_id, void *handle, const void *buf, size_t len)
 {
+    secure_session_t *session = handle;
     internal_socket_t *sock = int_socket_find_by_socket_id(socket_id);
     if(!sock){
         return -1;
     }
     if(!sock->real_socket){
         // Send to virtual socket cb
-        int ret = sock->parent->_send_cb(sock->listen_socket, address_ptr, port, buf, len);
+        int ret = sock->parent->_send_cb(sock->listen_socket, session->remote_address, session->remote_port, buf, len);
         if( ret < 0 )
             return ret;
         return len;
@@ -353,7 +359,7 @@ static int send_to_socket(int8_t socket_id, const uint8_t *address_ptr, uint16_t
     //For some reason socket_sendto returns 0 in success, while other socket impls return number of bytes sent!!!
     //TODO: check if address_ptr is valid and use that instead if it is
 
-    int8_t ret = send_to_real_socket(sock->listen_socket, &sock->dest_addr, source_addr, buf, len);
+    int8_t ret = send_to_real_socket(sock->listen_socket, &sock->dest_addr, session->remote_address, buf, len);
     if (ret < 0) {
         return ret;
     }
@@ -536,8 +542,8 @@ static void secure_recv_sckt_msg(void *cb_res)
         }
         session->last_contact_time = coap_service_get_internal_timer_ticks();
         // Start handshake
-        if (!session->sec_handler->_is_started) {
-            uint8_t *pw = (uint8_t *)ns_dyn_mem_alloc(64);
+        if (!coap_security_handler_is_started(session->sec_handler) ){
+            uint8_t *pw = ns_dyn_mem_alloc(64);
             uint8_t pw_len;
             if( sock->parent->_get_password_cb && 0 == sock->parent->_get_password_cb(sock->listen_socket, src_address.address, src_address.identifier, pw, &pw_len)){
                 //TODO: get_password_cb should support certs and PSK also
@@ -560,7 +566,7 @@ static void secure_recv_sckt_msg(void *cb_res)
                     if( sock->parent->_security_done_cb ){
                         sock->parent->_security_done_cb(sock->listen_socket, src_address.address,
                                                        src_address.identifier,
-                                                       session->sec_handler->_keyblk.value);
+                                                       (void *)coap_security_handler_keyblock(session->sec_handler));
                     }
                 } else if (ret < 0){
                     // error handling
@@ -641,8 +647,8 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
 
         session->last_contact_time = coap_service_get_internal_timer_ticks();
 
-        if (!session->sec_handler->_is_started) {
-            uint8_t *pw = (uint8_t *)ns_dyn_mem_alloc(64);
+        if (!coap_security_handler_is_started(session->sec_handler)) {
+            uint8_t *pw = ns_dyn_mem_alloc(64);
             uint8_t pw_len;
             if (sock->parent->_get_password_cb && 0 == sock->parent->_get_password_cb(sock->listen_socket, address, port, pw, &pw_len)) {
                 //TODO: get_password_cb should support certs and PSK also
@@ -665,7 +671,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
                     if( handler->_security_done_cb ){
                         handler->_security_done_cb(sock->listen_socket,
                                                   address, port,
-                                                  session->sec_handler->_keyblk.value);
+                                                  (void *)coap_security_handler_keyblock(session->sec_handler));
                     }
                     return 0;
                 }
@@ -807,7 +813,7 @@ int coap_connection_handler_send_data(coap_conn_handler_t *handler, const ns_add
             memcpy( handler->socket->dest_addr.address, dest_addr->address, 16 );
             handler->socket->dest_addr.identifier = dest_addr->identifier;
             handler->socket->dest_addr.type = dest_addr->type;
-            uint8_t *pw = (uint8_t *)ns_dyn_mem_alloc(64);
+            uint8_t *pw = ns_dyn_mem_alloc(64);
             if (!pw) {
                 //todo: free secure session?
                 return -1;

--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -6,19 +6,23 @@
 #include <time.h>
 #include <stdlib.h>
 
+#include "coap_security_handler.h"
+
+#ifdef COAP_SECURITY_AVAILABLE
+
 #include "mbedtls/sha256.h"
 #include "mbedtls/error.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/ssl_cookie.h"
+#include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
-#include "mbedtls/ssl.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/ssl_ciphersuites.h"
+
 #include "ns_trace.h"
 #include "nsdynmemLIB.h"
 #include "coap_connection_handler.h"
-#include "coap_security_handler.h"
 #include "randLIB.h"
-#include "mbedtls/ssl_ciphersuites.h"
-#include "socket_api.h"
 
 struct coap_security_s {
     mbedtls_ssl_config          _conf;
@@ -620,3 +624,5 @@ int entropy_poll( void *ctx, unsigned char *output, size_t len,
     ns_dyn_mem_free(c);
     return( 0 );
 }
+
+#endif // COAP_SECURITY_AVAILABLE

--- a/source/include/coap_security_handler.h
+++ b/source/include/coap_security_handler.h
@@ -38,7 +38,7 @@ typedef struct key_block {
     unsigned char value[KEY_BLOCK_LEN];
 } key_block_t;
 
-typedef int send_cb(int8_t socket_id, const uint8_t *address_ptr, uint16_t port, const uint8_t source_addr[static 16], const void *, size_t);
+typedef int send_cb(int8_t socket_id, void *handle, const void *buf, size_t);
 typedef int receive_cb(int8_t socket_id, unsigned char *, size_t);
 typedef void start_timer_cb(int8_t timer_id, uint32_t min, uint32_t fin);
 typedef int timer_status_cb(int8_t timer_id);
@@ -66,40 +66,9 @@ typedef struct {
     uint8_t _priv_len;
 } coap_security_keys_t;
 
-typedef struct coap_security_s {
-    mbedtls_ssl_config          _conf;
-    mbedtls_ssl_context         _ssl;
+typedef struct coap_security_s coap_security_t;
 
-    mbedtls_ctr_drbg_context    _ctr_drbg;
-    mbedtls_entropy_context     _entropy;
-    bool                        _is_started;
-    simple_cookie_t             _cookie;
-    key_block_t                 _keyblk;
-
-    SecureConnectionMode        _conn_mode;
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_x509_crt            _cacert;
-    mbedtls_x509_crt            _owncert;
-#endif
-    mbedtls_pk_context          _pkey;
-
-    uint8_t                     _remote_address[16];
-    uint16_t                    _remote_port;
-
-    uint8_t                     _pw[64];
-    uint8_t                     _pw_len;
-
-    bool                        _is_blocking;
-    int8_t                      _socket_id;
-    int8_t                      _timer_id;
-    send_cb                     *_send_cb;
-    receive_cb                  *_receive_cb;
-    start_timer_cb              *_start_timer_cb;
-    timer_status_cb             *_timer_status_cb;
-
-} coap_security_t;
-
-coap_security_t *coap_security_create(int8_t socket_id, int8_t timer_id, const uint8_t *address_ptr, uint16_t port,
+coap_security_t *coap_security_create(int8_t socket_id, int8_t timer_id, void *handle,
                                           SecureConnectionMode mode,
                                           send_cb *send_cb,
                                           receive_cb *receive_cb,
@@ -119,5 +88,9 @@ int coap_security_handler_send_message(coap_security_t *sec, unsigned char *mess
 int coap_security_send_close_alert(coap_security_t *sec);
 
 int coap_security_handler_read(coap_security_t *sec, unsigned char* buffer, size_t len);
+
+bool coap_security_handler_is_started(const coap_security_t *sec);
+
+const void *coap_security_handler_keyblock(const coap_security_t *sec);
 
 #endif

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -123,10 +123,7 @@ bool test_coap_connection_handler_send_data()
 
     connection_handler_destroy(handler);
 
-    coap_security_handler_stub.sec_obj = (coap_security_t *)malloc(sizeof(coap_security_t));
-    memset(coap_security_handler_stub.sec_obj, 0, sizeof(coap_security_t));
-    coap_security_handler_stub.sec_obj->_remote_port = 22;
-    memset(coap_security_handler_stub.sec_obj->_remote_address, 1, 16 );
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
@@ -200,10 +197,7 @@ bool test_coap_connection_handler_virtual_recv()
         return false;
 
     //handler->socket->data still in memory
-    coap_security_handler_stub.sec_obj = (coap_security_t *)malloc(sizeof(coap_security_t));
-    memset(coap_security_handler_stub.sec_obj, 0, sizeof(coap_security_t));
-    coap_security_handler_stub.sec_obj->_remote_port = 55;
-    memset(coap_security_handler_stub.sec_obj->_remote_address, 4, 16 );
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     ns_timer_stub.int8_value = -1;
     nsdynmemlib_stub.returnCounter = 3;
@@ -229,8 +223,6 @@ bool test_coap_connection_handler_virtual_recv()
 
     nsdynmemlib_stub.returnCounter = 1;
     coap_security_handler_stub.int_value = 0;
-    coap_security_handler_stub.sec_obj->_remote_port = 12;
-    memset(coap_security_handler_stub.sec_obj->_remote_address, 1, 16 );
     if( 0 != coap_connection_handler_virtual_recv(handler2,buf, 12, &buf, 1) )
         return false;
 
@@ -300,11 +292,7 @@ bool test_timer_callbacks()
         return false;
 
     //handler->socket->data still in memory
-    coap_security_handler_stub.sec_obj = (coap_security_t *)malloc(sizeof(coap_security_t));
-    memset(coap_security_handler_stub.sec_obj, 0, sizeof(coap_security_t));
-    coap_security_handler_stub.sec_obj->_remote_port = 55;
-    memset(coap_security_handler_stub.sec_obj->_remote_address, 4, 16 );
-    coap_security_handler_stub.sec_obj->_timer_id = 5;
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     ns_timer_stub.int8_value = 0;
     nsdynmemlib_stub.returnCounter = 3;
@@ -353,8 +341,7 @@ bool test_socket_api_callbacks()
     socket_callback_t *sckt_data = (socket_callback_t *)malloc(sizeof(socket_callback_t));
     memset(sckt_data, 0, sizeof(socket_callback_t));
 
-    coap_security_handler_stub.sec_obj = (coap_security_t *)malloc(sizeof(coap_security_t));
-    memset(coap_security_handler_stub.sec_obj, 0, sizeof(coap_security_t));
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     socket_api_stub.int8_value = 0;
     nsdynmemlib_stub.returnCounter = 1;
@@ -433,8 +420,7 @@ bool test_security_callbacks()
     socket_callback_t *sckt_data = (socket_callback_t *)malloc(sizeof(socket_callback_t));
     memset(sckt_data, 0, sizeof(socket_callback_t));
 
-    coap_security_handler_stub.sec_obj = (coap_security_t *)malloc(sizeof(coap_security_t));
-    memset(coap_security_handler_stub.sec_obj, 0, sizeof(coap_security_t));
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);

--- a/test/coap-service/unittest/coap_security_handler/test_coap_security_handler.c
+++ b/test/coap-service/unittest/coap_security_handler/test_coap_security_handler.c
@@ -8,7 +8,7 @@
 #include "mbedtls_stub.h"
 #include "mbedtls/ssl.h"
 
-static int send_to_socket(int8_t socket_id, uint8_t *address_ptr, uint16_t port, const unsigned char *buf, size_t len)
+static int send_to_socket(int8_t socket_id, void *handle, const unsigned char *buf, size_t len)
 {
 
 }
@@ -30,27 +30,26 @@ static int timer_status_callback(int8_t timer_id)
 
 bool test_thread_security_create()
 {
-    uint8_t buf[16];
-    if( NULL != coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, NULL) )
+    if( NULL != coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, NULL) )
         return false;
 
-    if( NULL != coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
+    if( NULL != coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 1;
     mbedtls_stub.expected_int = -1;
-    if( NULL != coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
+    if( NULL != coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
         return false;
 
     mbedtls_stub.expected_int = 0;
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = -1;
-    if( NULL != coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
+    if( NULL != coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -61,10 +60,9 @@ bool test_thread_security_create()
 
 bool test_thread_security_destroy()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -74,10 +72,9 @@ bool test_thread_security_destroy()
 
 bool test_coap_security_handler_connect()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -176,10 +173,9 @@ bool test_coap_security_handler_connect()
 
 bool test_coap_security_handler_continue_connecting()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -224,10 +220,9 @@ bool test_coap_security_handler_continue_connecting()
 
 bool test_coap_security_handler_send_message()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -245,10 +240,9 @@ bool test_coap_security_handler_send_message()
 
 bool test_thread_security_send_close_alert()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 
@@ -265,10 +259,9 @@ bool test_thread_security_send_close_alert()
 
 bool test_coap_security_handler_read()
 {
-    uint8_t buf[16];
     nsdynmemlib_stub.returnCounter = 2;
     mbedtls_stub.crt_expected_int = 0;
-    coap_security_t *handle = coap_security_create(1,2,&buf,12,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
+    coap_security_t *handle = coap_security_create(1,2,NULL,ECJPAKE,&send_to_socket, &receive_from_socket, &start_timer_callback, &timer_status_callback);
     if( NULL == handle )
         return false;
 

--- a/test/coap-service/unittest/makefile_defines.txt
+++ b/test/coap-service/unittest/makefile_defines.txt
@@ -32,7 +32,7 @@ INCLUDE_DIRS =\
   $(CPPUTEST_HOME)/include\
 
 CPPUTESTFLAGS = -D__thumb2__ -w 
-CPPUTEST_CFLAGS += -std=gnu99 
+CPPUTEST_CFLAGS += -std=gnu99 -DNS_USE_EXTERNAL_MBED_TLS
 
 #if you need to use -std=c++11 or c++0x you need to uncomment this
 #CPPUTESTFLAGS += -DCPPUTEST_STD_CPP_LIB_DISABLED 

--- a/test/coap-service/unittest/stub/coap_security_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_security_handler_stub.c
@@ -12,9 +12,12 @@
 
 thread_sec_def coap_security_handler_stub;
 
-coap_security_t *coap_security_create(int8_t socket_id, int8_t timer_id, const uint8_t *address_ptr, uint16_t port,
-                                          SecureConnectionMode mode,
-                                          int (*send_cb)(int8_t socket_id, const uint8_t *address_ptr, uint16_t port, const uint8_t source_addr[static 16], const void *, size_t),
+struct coap_security_s {
+    bool _is_started;
+};
+
+coap_security_t *coap_security_create(int8_t socket_id, int8_t timer_id, void *handle, SecureConnectionMode mode,
+                                          int (*send_cb)(int8_t socket_id, void *handle, const void *, size_t),
                                           int (*receive_cb)(int8_t socket_id, unsigned char *, size_t),
                                           void (*start_timer_cb)(int8_t timer_id, uint32_t min, uint32_t fin),
                                           int (*timer_status_cb)(int8_t timer_id))
@@ -25,6 +28,12 @@ coap_security_t *coap_security_create(int8_t socket_id, int8_t timer_id, const u
     coap_security_handler_stub.timer_status_cb = timer_status_cb;
     return coap_security_handler_stub.sec_obj;
 }
+
+coap_security_t *coap_security_handler_stub_alloc(void)
+{
+    return calloc(1, sizeof(coap_security_t));
+}
+
 
 void coap_security_destroy(coap_security_t *sec)
 {
@@ -72,4 +81,14 @@ int coap_security_handler_read(coap_security_t *sec, unsigned char* buffer, size
         return coap_security_handler_stub.values[coap_security_handler_stub.counter--];
     }
     return coap_security_handler_stub.int_value;
+}
+
+bool coap_security_handler_is_started(const coap_security_t *sec)
+{
+    return sec->_is_started;
+}
+
+const void *coap_security_handler_keyblock(const coap_security_t *sec)
+{
+    return NULL;
 }

--- a/test/coap-service/unittest/stub/coap_security_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_security_handler_stub.h
@@ -35,4 +35,6 @@ typedef struct tsh{
 
 extern thread_sec_def coap_security_handler_stub;
 
+coap_security_t *coap_security_handler_stub_alloc(void);
+
 #endif //__COAP_SECURITY_HANDLER_STUB_H__


### PR DESCRIPTION
NS_USE_EXTERNAL_MBED_TLS now controls whether we attempt to include
mbedTLS header files at all, and after including them, we check whether
SSL/TLS is enabled. If not, we provide non-secure operation only.