### PR TITLE
Delete all transactions when secure session is closed

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -92,6 +92,7 @@ static secure_session_t *secure_session_find_by_timer_id(int8_t timer_id)
 static void secure_session_delete(secure_session_t *this)
 {
     if (this) {
+        transactions_delete_all(this->parent->dest_addr.address, this->parent->dest_addr.identifier);
         ns_list_remove(&secure_session_list, this);
         if( this->sec_handler ){
             coap_security_destroy(this->sec_handler);
@@ -519,6 +520,7 @@ static void secure_recv_sckt_msg(void *cb_res)
     internal_socket_t *sock = int_socket_find_by_socket_id(sckt_data->socket_id);
     ns_address_t src_address;
     uint8_t dst_address[16];
+    memset(&src_address, 0, sizeof(ns_address_t));
 
     if (sock && read_data(sckt_data, sock, &src_address, dst_address) == 0) {
         secure_session_t *session = secure_session_find(sock, src_address.address, src_address.identifier);

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -93,6 +93,17 @@ void transaction_delete(coap_transaction_t *this)
     return;
 }
 
+void transactions_delete_all(uint8_t *address_ptr, uint16_t port)
+{
+    coap_transaction_t *transaction = transaction_find_by_address(address_ptr, port);
+
+    while (transaction) {
+        sn_coap_protocol_delete_retransmission(coap_service_handle->coap, transaction->msg_id);
+        transaction_delete(transaction);
+        transaction = transaction_find_by_address(address_ptr, port);
+    }
+}
+
 static int8_t coap_rx_function(sn_coap_hdr_s *resp_ptr, sn_nsdl_addr_s *address_ptr, void *param)
 {
     coap_transaction_t *this = NULL;

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -88,4 +88,6 @@ extern int8_t coap_message_handler_exec(coap_msg_handler_t *handle, uint32_t cur
 
 extern void transaction_delete(coap_transaction_t *this);
 
+extern void transactions_delete_all(uint8_t *address_ptr, uint16_t port);
+
 #endif

--- a/source/include/coap_service_api_internal.h
+++ b/source/include/coap_service_api_internal.h
@@ -19,6 +19,10 @@
 #ifndef __COAP_SERVICE_API_INTERNAL_H__
 #define __COAP_SERVICE_API_INTERNAL_H__
 
+#include "coap_message_handler.h"
+
+
+extern coap_msg_handler_t *coap_service_handle;
 
 uint32_t coap_service_get_internal_timer_ticks(void);
 

--- a/test/coap-service/unittest/coap_connection_handler/Makefile
+++ b/test/coap-service/unittest/coap_connection_handler/Makefile
@@ -18,6 +18,7 @@ TEST_SRC_FILES = \
 	../stub/socket_api_stub.c \
 	../stub/coap_security_handler_stub.c \
 	../stub/coap_service_api_stub.c \
+	../stub/coap_message_handler_stub.c \
 
 include ../MakefileWorker.mk
 

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -22,6 +22,10 @@ void transaction_delete(coap_transaction_t *this)
 
 }
 
+void transactions_delete_all(uint8_t *address_ptr, uint16_t port)
+{
+
+}
 int8_t coap_message_handler_destroy(coap_msg_handler_t *handle)
 {
     return coap_message_handler_stub.int8_value;

--- a/test/coap-service/unittest/stub/coap_service_api_stub.c
+++ b/test/coap-service/unittest/stub/coap_service_api_stub.c
@@ -18,6 +18,8 @@
 #include "common_functions.h"
 #include "net_interface.h"
 
+coap_msg_handler_t *coap_service_handle = NULL;
+
 int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options,
                                  coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *coap_security_done_cb)
 {

--- a/test/coap-service/unittest/stub/sn_coap_protocol_stub.c
+++ b/test/coap-service/unittest/stub/sn_coap_protocol_stub.c
@@ -94,3 +94,7 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
     return sn_coap_protocol_stub.expectedSendMsg;
 }
 
+int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t msg_id)
+{
+    return 0;
+}


### PR DESCRIPTION
When handshake fails, or DTLS session is closed, all transactions must
be removed from coap protocol retransmission queue. Otherwise coap
retransmission will start new handshake.

@mikter @artokin - please review