### PR TITLE
Use default local address, if request is from multicast address

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -533,6 +533,10 @@ static void secure_recv_sckt_msg(void *cb_res)
     memset(&src_address, 0, sizeof(ns_address_t));
 
     if (sock && read_data(sckt_data, sock, &src_address, dst_address) == 0) {
+        /* If received from multicast address, reject */
+        if (*(dst_address) == 0xFF) {
+            return;
+        }
         secure_session_t *session = secure_session_find(sock, src_address.address, src_address.identifier);
 
         // Create session

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -7,6 +7,7 @@
 #include "coap_service_api_internal.h"
 #include "coap_message_handler.h"
 #include "sn_coap_protocol.h"
+#include "socket_api.h"
 #include "ns_types.h"
 #include "ns_list.h"
 #include "ns_trace.h"
@@ -220,7 +221,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
             transaction_ptr->service_id = coap_service_id_find_by_socket(socket_id);
             transaction_ptr->msg_id = coap_message->msg_id;
             transaction_ptr->client_request = false;// this is server transaction
-            memcpy(transaction_ptr->local_address, dst_addr_ptr, 16);
+            memcpy(transaction_ptr->local_address, *(dst_addr_ptr) == 0xFF ? ns_in6addr_any : dst_addr_ptr, 16);
             memcpy(transaction_ptr->remote_address, source_addr_ptr, 16);
             transaction_ptr->remote_port = port;
 

--- a/test/coap-service/unittest/stub/socket_api_stub.c
+++ b/test/coap-service/unittest/stub/socket_api_stub.c
@@ -33,7 +33,7 @@ int8_t socket_free(int8_t socket)
 
     return socket_api_stub.int8_value;
 }
-int8_t socket_listen(int8_t socket, uint8_t backlog)
+int8_t socket_listen(int8_t socket, ...)
 {
     if( socket_api_stub.counter >= 0){
         return socket_api_stub.values[socket_api_stub.counter--];


### PR DESCRIPTION
If response to multicast request is sent, local address must be set to
default.

@artokin @mikter @jpellikk-arm - please review