### PR TITLE
Addding backlog parameter to socket_listen

### DIFF
--- a/test/coap-service/unittest/stub/socket_api_stub.c
+++ b/test/coap-service/unittest/stub/socket_api_stub.c
@@ -33,7 +33,7 @@ int8_t socket_free(int8_t socket)
 
     return socket_api_stub.int8_value;
 }
-int8_t socket_listen(int8_t socket)
+int8_t socket_listen(int8_t socket, uint8_t backlog)
 {
     if( socket_api_stub.counter >= 0){
         return socket_api_stub.values[socket_api_stub.counter--];


### PR DESCRIPTION
* As part of patch-2 for socket API update, we need to add 2nd parameter of socket_listen() API.