### PR TITLE
Call transaction callback when transactions are deleted

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -95,8 +95,8 @@ static secure_session_t *secure_session_find_by_timer_id(int8_t timer_id)
 static void secure_session_delete(secure_session_t *this)
 {
     if (this) {
-        transactions_delete_all(this->remote_host.address, this->remote_host.identifier);
         ns_list_remove(&secure_session_list, this);
+        transactions_delete_all(this->remote_host.address, this->remote_host.identifier);
         if( this->sec_handler ){
             coap_security_destroy(this->sec_handler);
             this->sec_handler = NULL;
@@ -529,7 +529,7 @@ static void secure_recv_sckt_msg(void *cb_res)
     socket_callback_t *sckt_data = cb_res;
     internal_socket_t *sock = int_socket_find_by_socket_id(sckt_data->socket_id);
     ns_address_t src_address;
-    uint8_t dst_address[16];
+    uint8_t dst_address[16] = {0};
     memset(&src_address, 0, sizeof(ns_address_t));
 
     if (sock && read_data(sckt_data, sock, &src_address, dst_address) == 0) {

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -99,6 +99,9 @@ void transactions_delete_all(uint8_t *address_ptr, uint16_t port)
     coap_transaction_t *transaction = transaction_find_by_address(address_ptr, port);
 
     while (transaction) {
+        if (transaction->resp_cb) {
+            transaction->resp_cb(transaction->service_id, address_ptr, port, NULL);
+        }
         sn_coap_protocol_delete_retransmission(coap_service_handle->coap, transaction->msg_id);
         transaction_delete(transaction);
         transaction = transaction_find_by_address(address_ptr, port);


### PR DESCRIPTION
When secure session is deleted, transaction callback must be called
to inform request sender that response is not going to be received.

@mikter @artokin - please review