### PR TITLE
Support for multiple virtual services

### DIFF
--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -235,7 +235,7 @@ static int send_cb(int8_t socket_id, const uint8_t address[static 16], uint16_t 
 {
     coap_service_t *this = service_find_by_socket(socket_id);
     if (this && this->virtual_socket_send_cb) {
-        tr_debug("send to virtual socket");
+        tr_debug("send to virtual socket, service: %d", this->service_id);
         return this->virtual_socket_send_cb(this->service_id, (uint8_t*)address, port, data_ptr, data_len);
     }
     return -1;
@@ -380,7 +380,7 @@ int16_t coap_service_virtual_socket_recv(int8_t service_id, uint8_t source_addr_
 int16_t coap_service_virtual_socket_set_cb(int8_t service_id, coap_service_virtual_socket_send_cb *send_method_ptr)
 {
     coap_service_t *this = service_find(service_id);
-    tr_debug("register virtual socket cb");
+    tr_debug("register virtual socket cb to service %d", service_id);
     if (!this) {
         return -1;
     }


### PR DESCRIPTION
Socket id is initialized to -1 when virtual service is used.
Therefore it is not possible to search virtual service based on
socket id.

Use negative socket id's to identify virtual services.

share same socket ID coap-service supports one virtual socket.