### PR TITLE
Add option to select used socket interface

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -45,6 +45,8 @@ extern "C" {
 #define COAP_SERVICE_OPTIONS_VIRTUAL_SOCKET     0x01
 #define COAP_SERVICE_OPTIONS_SECURE 	        0x02
 #define COAP_SERVICE_OPTIONS_EPHEMERAL_PORT     0x04
+/** Coap interface selected as socket interface */
+#define COAP_SERVICE_OPTIONS_SELECT_SOCKET_IF   0x08
 /** Link-layer security bypass option is set*/
 #define COAP_SERVICE_OPTIONS_SECURE_BYPASS      0x80
 

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -315,11 +315,11 @@ int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_
     }
 
     if (0 > coap_connection_handler_open_connection(this->conn_handler, listen_port,
-            ((this->service_options & COAP_SERVICE_OPTIONS_EPHEMERAL_PORT) == COAP_SERVICE_OPTIONS_EPHEMERAL_PORT),
-            ((this->service_options & COAP_SERVICE_OPTIONS_SECURE) == COAP_SERVICE_OPTIONS_SECURE),
-            ((this->service_options & COAP_SERVICE_OPTIONS_VIRTUAL_SOCKET) != COAP_SERVICE_OPTIONS_VIRTUAL_SOCKET),
-            ((this->service_options & COAP_SERVICE_OPTIONS_SECURE_BYPASS) == COAP_SERVICE_OPTIONS_SECURE_BYPASS),
-              socket_interface_selection)) {
+            (this->service_options & COAP_SERVICE_OPTIONS_EPHEMERAL_PORT),
+            (this->service_options & COAP_SERVICE_OPTIONS_SECURE),
+            !(this->service_options & COAP_SERVICE_OPTIONS_VIRTUAL_SOCKET),
+            (this->service_options & COAP_SERVICE_OPTIONS_SECURE_BYPASS),
+             socket_interface_selection)) {
         ns_dyn_mem_free(this->conn_handler);
         ns_dyn_mem_free(this);
         return -1;

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -55,7 +55,7 @@ void connection_handler_destroy( coap_conn_handler_t *handler );
 
 void connection_handler_close_secure_connection( coap_conn_handler_t *handler, uint8_t destination_addr_ptr[static 16], uint16_t port );
 
-int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec);
+int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec, int8_t socket_interface_selection);
 
 //If returns -2, it means security was started and data was not send
 int coap_connection_handler_send_data(coap_conn_handler_t *handler, const ns_address_t *dest_addr, const uint8_t src_address[static 16], uint8_t *data_ptr, uint16_t data_len, bool bypass_link_sec);

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -67,34 +67,34 @@ bool test_coap_connection_handler_open_connection()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, NULL, NULL, NULL);
 
-    if( -1 != coap_connection_handler_open_connection(NULL, 0,false,false,false,false) )
+    if( -1 != coap_connection_handler_open_connection(NULL, 0,false,false,false,false,-1) )
         return false;
 
-    if( -1 != coap_connection_handler_open_connection(handler, 0,false,false,false,false) )
+    if( -1 != coap_connection_handler_open_connection(handler, 0,false,false,false,false,-1) )
         return false;
 
     ns_dyn_mem_free(handler);
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
-    if( -1 != coap_connection_handler_open_connection(handler, 0,true,true,true,false) )
+    if( -1 != coap_connection_handler_open_connection(handler, 0,true,true,true,false,-1) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 0,true,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 0,true,true,true,false,-1) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,true) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,true,-1) )
         return false;
 
     //open second one
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,true) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,true,-1) )
         return false;
 
-    if( 0 != coap_connection_handler_open_connection(handler, 23,false,false,false,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 23,false,false,false,false,-1) )
         return false;
 
     connection_handler_destroy(handler2);
@@ -115,7 +115,7 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false,-1) )
         return false;
 
     if( -1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
@@ -128,7 +128,7 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 4;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false,-1) )
         return false;
 
     if( -1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
@@ -146,7 +146,7 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,false,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,false,false,-1) )
         return false;
 
 
@@ -157,7 +157,7 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false,-1) )
         return false;
 
     socket_api_stub.int8_value = 7;
@@ -181,7 +181,7 @@ bool test_coap_connection_handler_virtual_recv()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
         return false;
 
     if( -1 != coap_connection_handler_virtual_recv(handler,buf, 12, NULL, 0) )
@@ -214,7 +214,7 @@ bool test_coap_connection_handler_virtual_recv()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 24,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 24,false,true,true,false,-1) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 3;
@@ -243,7 +243,7 @@ bool test_coap_connection_handler_virtual_recv()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler3 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler3, 26,false,false,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler3, 26,false,false,true,false,-1) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 3;
@@ -265,7 +265,7 @@ bool test_coap_connection_handler_socket_belongs_to()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
         return false;
 
     if( true != coap_connection_handler_socket_belongs_to(handler, 0) )
@@ -288,7 +288,7 @@ bool test_timer_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
         return false;
 
     //handler->socket->data still in memory
@@ -347,7 +347,7 @@ bool test_socket_api_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false,-1) )
         return false;
 
     if( socket_api_stub.recv_cb ){
@@ -369,7 +369,7 @@ bool test_socket_api_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,false,-1) )
         return false;
 
     if( socket_api_stub.recv_cb ){
@@ -425,7 +425,7 @@ bool test_security_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
         return false;
 
     if( socket_api_stub.recv_cb ){

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -41,7 +41,7 @@ void connection_handler_close_secure_connection( coap_conn_handler_t *handler, u
 
 }
 
-int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec)
+int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec, int8_t socket_interface_selection)
 {
     return thread_conn_handler_stub.int_value;
 }


### PR DESCRIPTION
Add new COAP service option COAP_SERVICE_OPTIONS_SELECT_SOCKET_IF.
When option is set then COAP interface ID will be selected as socket
interface.