### PR TITLE
CoAP: Dont't delete transaction on failed transmission if no response callback set

### DIFF
--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -150,8 +150,6 @@ static uint8_t coap_tx_function(uint8_t *data_ptr, uint16_t data_len, sn_nsdl_ad
         }
         memcpy(transaction_ptr->data_ptr, data_ptr, data_len);
         transaction_ptr->data_len = data_len;
-    } else if (transaction_ptr->resp_cb == NULL ) {
-        transaction_delete(transaction_ptr);
     }
 
     return 0;


### PR DESCRIPTION
@terhei @mikter @artokin @deepakvenugopal Please review; is there a good reason why this piece of code existed?