### PR TITLE
Register to multicast groups

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -59,7 +59,8 @@ extern "C" {
 #define COAP_REQUEST_OPTIONS_SECURE_BYPASS      0x08
 
 extern const uint8_t COAP_MULTICAST_ADDR_LINK_LOCAL[16]; //!< ff02::fd, COAP link local multicast address
-extern const uint8_t COAP_MULTICAST_ADDR_SITE_LOCAL[16]; //!> ff05::fd, COAP site local multicast address
+extern const uint8_t COAP_MULTICAST_ADDR_ADMIN_LOCAL[16]; //!< ff03::fd, COAP admin-local multicast address
+extern const uint8_t COAP_MULTICAST_ADDR_SITE_LOCAL[16]; //!> ff05::fd, COAP site-local multicast address
 
 /**
  * \brief Service message response receive callback.

--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -58,6 +58,9 @@ extern "C" {
 #define COAP_REQUEST_OPTIONS_MULTICAST          0x04 //!< indicates that CoAP library support multicasting
 #define COAP_REQUEST_OPTIONS_SECURE_BYPASS      0x08
 
+extern const uint8_t COAP_MULTICAST_ADDR_LINK_LOCAL[16]; //!< ff02::fd, COAP link local multicast address
+extern const uint8_t COAP_MULTICAST_ADDR_SITE_LOCAL[16]; //!> ff05::fd, COAP site local multicast address
+
 /**
  * \brief Service message response receive callback.
  *

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -280,7 +280,7 @@ static int get_passwd_cb(int8_t socket_id, uint8_t address[static 16], uint16_t 
 int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options,
                                  coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *coap_security_done_cb)
 {
-    int8_t socket_interface_selection = -1;
+    int8_t socket_interface_selection = 0; // zero is illegal interface ID
     coap_service_t *this = ns_dyn_mem_alloc(sizeof(coap_service_t));
     if (!this) {
         return -1;


### PR DESCRIPTION
COAP service registers automatically to COAP multicast groups:
-ff02::fd (link-local according to RFC 7390)
-ff05::fd (site local according to RFC 7390)