### PR TITLE
Add option to join COAP multicast group

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -47,6 +47,8 @@ extern "C" {
 #define COAP_SERVICE_OPTIONS_EPHEMERAL_PORT     0x04
 /** Coap interface selected as socket interface */
 #define COAP_SERVICE_OPTIONS_SELECT_SOCKET_IF   0x08
+/** Register to COAP multicast groups */
+#define COAP_SERVICE_OPTIONS_MULTICAST_JOIN     0x10
 /** Link-layer security bypass option is set*/
 #define COAP_SERVICE_OPTIONS_SECURE_BYPASS      0x80
 

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -228,18 +228,23 @@ static secure_session_t *secure_session_find(internal_socket_t *parent, const ui
 static void coap_multicast_group_join_or_leave(int8_t socket_id, uint8_t opt_name, int8_t interface_id)
 {
     ns_ipv6_mreq_t ns_ipv6_mreq;
+    int8_t ret_val;
 
     // Join or leave COAP multicast groups
     ns_ipv6_mreq.ipv6mr_interface = interface_id;
 
     memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_LINK_LOCAL, 16);
-    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+    ret_val = socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
 
     memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_ADMIN_LOCAL, 16);
-    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+    ret_val |= socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
 
     memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_SITE_LOCAL, 16);
-    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+    ret_val |= socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+
+    if (ret_val) {
+        tr_error("Multicast group access failed, err=%d, name=%d", ret_val, opt_name);
+    }
 }
 
 static internal_socket_t *int_socket_create(uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec, int8_t socket_interface_selection, bool multicast_registration)

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -225,9 +225,25 @@ static secure_session_t *secure_session_find(internal_socket_t *parent, const ui
     return this;
 }
 
-static internal_socket_t *int_socket_create(uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec, int8_t socket_interface_selection)
+static void coap_multicast_group_join_or_leave(int8_t socket_id, uint8_t opt_name, int8_t interface_id)
 {
     ns_ipv6_mreq_t ns_ipv6_mreq;
+
+    // Join or leave COAP multicast groups
+    ns_ipv6_mreq.ipv6mr_interface = interface_id;
+
+    memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_LINK_LOCAL, 16);
+    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+
+    memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_ADMIN_LOCAL, 16);
+    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+
+    memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_SITE_LOCAL, 16);
+    socket_setsockopt(socket_id, SOCKET_IPPROTO_IPV6, opt_name, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+}
+
+static internal_socket_t *int_socket_create(uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec, int8_t socket_interface_selection, bool multicast_registration)
+{
     internal_socket_t *this = ns_dyn_mem_alloc(sizeof(internal_socket_t));
 
     if (!this) {
@@ -276,17 +292,9 @@ static internal_socket_t *int_socket_create(uint16_t listen_port, bool use_ephem
             socket_setsockopt(this->socket, SOCKET_IPPROTO_IPV6, SOCKET_INTERFACE_SELECT, &socket_interface_selection, sizeof(socket_interface_selection));
         }
 
-        // Join COAP multicast group(s)
-        ns_ipv6_mreq.ipv6mr_interface = socket_interface_selection; // It is OK to use 0 or real interface id here
-
-        memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_LINK_LOCAL, 16);
-        socket_setsockopt(this->socket, SOCKET_IPPROTO_IPV6, SOCKET_IPV6_JOIN_GROUP, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
-
-        memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_ADMIN_LOCAL, 16);
-        socket_setsockopt(this->socket, SOCKET_IPPROTO_IPV6, SOCKET_IPV6_JOIN_GROUP, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
-
-        memcpy(ns_ipv6_mreq.ipv6mr_multiaddr, COAP_MULTICAST_ADDR_SITE_LOCAL, 16);
-        socket_setsockopt(this->socket, SOCKET_IPPROTO_IPV6, SOCKET_IPV6_JOIN_GROUP, &ns_ipv6_mreq, sizeof(ns_ipv6_mreq));
+        if (multicast_registration) {
+            coap_multicast_group_join_or_leave(this->socket, SOCKET_IPV6_JOIN_GROUP, socket_interface_selection);
+        }
     } else {
         this->socket = virtual_socket_id_allocate();
     }
@@ -793,9 +801,13 @@ coap_conn_handler_t *connection_handler_create(receive_from_socket_cb *recv_from
 
     return handler;
 }
-void connection_handler_destroy(coap_conn_handler_t *handler)
+
+void connection_handler_destroy(coap_conn_handler_t *handler, bool multicast_group_leave)
 {
     if(handler){
+        if (multicast_group_leave) {
+            coap_multicast_group_join_or_leave(handler->socket->socket, SOCKET_IPV6_LEAVE_GROUP, handler->socket_interface_selection);
+        }
        int_socket_delete(handler->socket);
        ns_dyn_mem_free(handler);
     }
@@ -815,7 +827,7 @@ void connection_handler_close_secure_connection( coap_conn_handler_t *handler, u
     }
 }
 
-int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec, int8_t socket_interface_selection)
+int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec)
 {
     if (!handler) {
         return -1;
@@ -830,7 +842,7 @@ int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16
 
     internal_socket_t *current = !use_ephemeral_port?int_socket_find(listen_port, is_secure, is_real_socket, bypassSec):NULL;
     if (!current) {
-        handler->socket = int_socket_create(listen_port, use_ephemeral_port, is_secure, is_real_socket, bypassSec, socket_interface_selection);
+        handler->socket = int_socket_create(listen_port, use_ephemeral_port, is_secure, is_real_socket, bypassSec, handler->socket_interface_selection, handler->registered_to_multicast);
         if (!handler->socket) {
             return -1;
         }

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -44,6 +44,8 @@ typedef struct coap_conn_handler_s{
     send_to_socket_cb *_send_cb;
     get_pw_cb *_get_password_cb;
     security_done_cb *_security_done_cb;
+    int8_t socket_interface_selection;
+    bool registered_to_multicast;
 } coap_conn_handler_t;
 
 coap_conn_handler_t *connection_handler_create(receive_from_socket_cb *recv_from_cb,
@@ -51,11 +53,11 @@ coap_conn_handler_t *connection_handler_create(receive_from_socket_cb *recv_from
                                                  get_pw_cb *pw_cb,
                                                  security_done_cb *done_cb);
 
-void connection_handler_destroy( coap_conn_handler_t *handler );
+void connection_handler_destroy( coap_conn_handler_t *handler, bool multicast_group_leave);
 
 void connection_handler_close_secure_connection( coap_conn_handler_t *handler, uint8_t destination_addr_ptr[static 16], uint16_t port );
 
-int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec, int8_t socket_interface_selection);
+int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec);
 
 //If returns -2, it means security was started and data was not send
 int coap_connection_handler_send_data(coap_conn_handler_t *handler, const ns_address_t *dest_addr, const uint8_t src_address[static 16], uint8_t *data_ptr, uint16_t data_len, bool bypass_link_sec);

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -57,7 +57,7 @@ bool test_connection_handler_destroy()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, NULL, NULL, NULL);
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
     return true;
 }
 
@@ -67,38 +67,38 @@ bool test_coap_connection_handler_open_connection()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, NULL, NULL, NULL);
 
-    if( -1 != coap_connection_handler_open_connection(NULL, 0,false,false,false,false,-1) )
+    if( -1 != coap_connection_handler_open_connection(NULL, 0,false,false,false,false) )
         return false;
 
-    if( -1 != coap_connection_handler_open_connection(handler, 0,false,false,false,false,-1) )
+    if( -1 != coap_connection_handler_open_connection(handler, 0,false,false,false,false) )
         return false;
 
     ns_dyn_mem_free(handler);
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
-    if( -1 != coap_connection_handler_open_connection(handler, 0,true,true,true,false,-1) )
+    if( -1 != coap_connection_handler_open_connection(handler, 0,true,true,true,false) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 0,true,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 0,true,true,true,false) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,true,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,true) )
         return false;
 
     //open second one
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,true,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,true) )
         return false;
 
-    if( 0 != coap_connection_handler_open_connection(handler, 23,false,false,false,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 23,false,false,false,false) )
         return false;
 
-    connection_handler_destroy(handler2);
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler2, false);
+    connection_handler_destroy(handler, false);
     return true;
 }
 
@@ -115,20 +115,20 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false) )
         return false;
 
     if( -1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
         return false;
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
 
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 4;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,false,false) )
         return false;
 
     if( -1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
@@ -137,7 +137,7 @@ bool test_coap_connection_handler_send_data()
     if( -1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
         return false;
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     free(coap_security_handler_stub.sec_obj);
     coap_security_handler_stub.sec_obj = NULL;
@@ -146,24 +146,24 @@ bool test_coap_connection_handler_send_data()
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,false,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,false,false) )
         return false;
 
 
     if( 1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
         return false;
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler ,false);
 
     nsdynmemlib_stub.returnCounter = 1;
     handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false) )
         return false;
 
     socket_api_stub.int8_value = 7;
     if( 7 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
         return false;
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     //<-- NON SECURE HERE
 
@@ -181,7 +181,7 @@ bool test_coap_connection_handler_virtual_recv()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
         return false;
 
     if( -1 != coap_connection_handler_virtual_recv(handler,buf, 12, NULL, 0) )
@@ -209,12 +209,12 @@ bool test_coap_connection_handler_virtual_recv()
     if( -1 != coap_connection_handler_virtual_recv(handler,buf, 12, &buf, 1) )
         return false;
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 24,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 24,false,true,true,false) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 3;
@@ -235,7 +235,7 @@ bool test_coap_connection_handler_virtual_recv()
     if( 0 != coap_connection_handler_virtual_recv(handler2,buf, 12, &buf, 1) )
         return false;
 
-    connection_handler_destroy(handler2);
+    connection_handler_destroy(handler2, false);
 
     free(coap_security_handler_stub.sec_obj);
     coap_security_handler_stub.sec_obj = NULL;
@@ -243,14 +243,14 @@ bool test_coap_connection_handler_virtual_recv()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler3 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler3, 26,false,false,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler3, 26,false,false,true,false) )
         return false;
 
     nsdynmemlib_stub.returnCounter = 3;
     if( 0 != coap_connection_handler_virtual_recv(handler3,buf, 12, &buf, 1) )
         return false;
 
-    connection_handler_destroy(handler3);
+    connection_handler_destroy(handler3, false);
 
     return true;
 }
@@ -265,7 +265,7 @@ bool test_coap_connection_handler_socket_belongs_to()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
         return false;
 
     if( true != coap_connection_handler_socket_belongs_to(handler, 0) )
@@ -273,7 +273,7 @@ bool test_coap_connection_handler_socket_belongs_to()
 
     if( false != coap_connection_handler_socket_belongs_to(handler, 3) )
         return false;
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     nsdynmemlib_stub.returnCounter = 0;
     return true;
@@ -288,7 +288,7 @@ bool test_timer_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
         return false;
 
     //handler->socket->data still in memory
@@ -326,7 +326,7 @@ bool test_timer_callbacks()
         coap_security_handler_stub.int_value = 0;
     }
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
     free(coap_security_handler_stub.sec_obj);
     coap_security_handler_stub.sec_obj = NULL;
     return true;
@@ -347,7 +347,7 @@ bool test_socket_api_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,false,true,false) )
         return false;
 
     if( socket_api_stub.recv_cb ){
@@ -364,12 +364,12 @@ bool test_socket_api_callbacks()
         socket_api_stub.recv_cb(sckt_data);
     }
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler2 = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, &get_passwd_cb, &sec_done_cb);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler2, 22,false,true,true,false) )
         return false;
 
     if( socket_api_stub.recv_cb ){
@@ -401,7 +401,7 @@ bool test_socket_api_callbacks()
         socket_api_stub.recv_cb(sckt_data);
     }
 
-    connection_handler_destroy(handler2);
+    connection_handler_destroy(handler2, false);
 
     free(coap_security_handler_stub.sec_obj);
     coap_security_handler_stub.sec_obj = NULL;
@@ -425,7 +425,7 @@ bool test_security_callbacks()
     nsdynmemlib_stub.returnCounter = 1;
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
-    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false,-1) )
+    if( 0 != coap_connection_handler_open_connection(handler, 22,false,true,true,false) )
         return false;
 
     if( socket_api_stub.recv_cb ){
@@ -444,7 +444,7 @@ bool test_security_callbacks()
         coap_security_handler_stub.receive_cb(0, &buf, 16);
     }
 
-    connection_handler_destroy(handler);
+    connection_handler_destroy(handler, false);
 
     free(coap_security_handler_stub.sec_obj);
     coap_security_handler_stub.sec_obj = NULL;

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -32,7 +32,7 @@ coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, 
     return thread_conn_handler_stub.handler_obj;
 }
 
-void connection_handler_destroy(coap_conn_handler_t *handler)
+void connection_handler_destroy( coap_conn_handler_t *handler, bool multicast_group_leave)
 {
 
 }
@@ -41,7 +41,7 @@ void connection_handler_close_secure_connection( coap_conn_handler_t *handler, u
 
 }
 
-int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec, int8_t socket_interface_selection)
+int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool is_real_socket, bool bypassSec)
 {
     return thread_conn_handler_stub.int_value;
 }


### PR DESCRIPTION
Option COAP_SERVICE_OPTIONS_MULTICAST_JOIN added to service_api to
join COAP multicast group. The group is left when service is deleted.