### PR TITLE
Disable CoAP duplicate message detection

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -282,6 +282,7 @@ extern int8_t coap_service_response_send(int8_t service_id, uint8_t options, sn_
  *-         0              For success
  */
 extern int8_t coap_service_request_delete(int8_t service_id, uint16_t msg_id);
+
 /**
  * \brief Set DTLS handshake timeout values
  *
@@ -295,6 +296,19 @@ extern int8_t coap_service_request_delete(int8_t service_id, uint16_t msg_id);
  *-         0              For success
  */
 extern int8_t coap_service_set_handshake_timeout(int8_t service_id, uint32_t min, uint32_t max);
+
+/**
+ * \brief Set CoAP duplication message buffer size
+ *
+ * Configures the CoAP duplication message buffer size.
+ *
+ * \param service_id       Id number of the current service.
+ * \param size             Buffer size (messages)
+ *
+ * \return -1              For failure
+ *-         0              For success
+ */
+extern int8_t coap_service_set_duplicate_message_buffer(int8_t service_id, uint8_t size);
 #ifdef __cplusplus
 }
 #endif

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -180,6 +180,10 @@ coap_msg_handler_t *coap_message_handler_init(void *(*used_malloc_func_ptr)(uint
         used_free_func_ptr(handle);
         return NULL;
     }
+
+    /* Disable CoAP protocol duplicate message detection */
+    sn_coap_protocol_set_duplicate_buffer_size(handle->coap, 0);
+
     return handle;
 }
 

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -181,7 +181,7 @@ coap_msg_handler_t *coap_message_handler_init(void *(*used_malloc_func_ptr)(uint
         return NULL;
     }
 
-    /* Disable CoAP protocol duplicate message detection */
+    /* Set default buffer size for CoAP duplicate message detection */
     sn_coap_protocol_set_duplicate_buffer_size(handle->coap, DUPLICATE_MESSAGE_BUFFER_SIZE);
 
     return handle;

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -182,7 +182,7 @@ coap_msg_handler_t *coap_message_handler_init(void *(*used_malloc_func_ptr)(uint
     }
 
     /* Disable CoAP protocol duplicate message detection */
-    sn_coap_protocol_set_duplicate_buffer_size(handle->coap, 0);
+    sn_coap_protocol_set_duplicate_buffer_size(handle->coap, DUPLICATE_MESSAGE_BUFFER_SIZE);
 
     return handle;
 }

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -21,6 +21,7 @@
 #include "net_interface.h"
 #include "coap_service_api_internal.h"
 #include "coap_message_handler.h"
+#include "mbed-coap/sn_coap_protocol.h"
 
 static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr);
 
@@ -506,6 +507,17 @@ int8_t coap_service_set_handshake_timeout(int8_t service_id, uint32_t min, uint3
     }
 
     return coap_connection_handler_set_timeout(this->conn_handler, min, max);
+}
+
+int8_t coap_service_set_duplicate_message_buffer(int8_t service_id, uint8_t size)
+{
+    (void) service_id;
+
+    if (!coap_service_handle) {
+        return -1;
+    }
+
+    return sn_coap_protocol_set_duplicate_buffer_size(coap_service_handle->coap, size);
 }
 
 uint32_t coap_service_get_internal_timer_ticks(void)

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -24,6 +24,7 @@
 #include "ns_list.h"
 
 #define TRANSACTION_LIFETIME 180
+#define DUPLICATE_MESSAGE_BUFFER_SIZE 0
 
 /**
  * \brief Service message response receive callback.

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -24,6 +24,7 @@
 #include "ns_list.h"
 
 #define TRANSACTION_LIFETIME 180
+/* Default value for CoAP duplicate message buffer (0 = disabled) */
 #define DUPLICATE_MESSAGE_BUFFER_SIZE 0
 
 /**

--- a/test/coap-service/unittest/coap_service_api/Makefile
+++ b/test/coap-service/unittest/coap_service_api/Makefile
@@ -17,7 +17,8 @@ TEST_SRC_FILES = \
 	../stub/eventOS_event_stub.c \
 	../stub/coap_connection_handler_stub.c \
 	../stub/coap_message_handler_stub.c \
-	../stub/common_functions_stub.c
+	../stub/common_functions_stub.c \
+	../stub/sn_coap_protocol_stub.c
 
 include ../MakefileWorker.mk
 


### PR DESCRIPTION
To save some memory, CoAP duplicate message detection is disabled by
default.

@mikter @artokin - please review