### PR TITLE
Fix redefinition of mbed TLS error codes

### DIFF
--- a/source/include/coap_security_handler.h
+++ b/source/include/coap_security_handler.h
@@ -101,10 +101,21 @@ const void *coap_security_handler_keyblock(const coap_security_t *sec);
 NS_DUMMY_DEFINITIONS_OK
 
 /* Dummy definitions, including needed error codes */
+#ifndef MBEDTLS_ERR_SSL_TIMEOUT
 #define MBEDTLS_ERR_SSL_TIMEOUT (-1)
+#endif
+
+#ifndef MBEDTLS_ERR_SSL_WANT_READ
 #define MBEDTLS_ERR_SSL_WANT_READ (-2)
+#endif
+
+#ifndef MBEDTLS_ERR_SSL_WANT_WRITE
 #define MBEDTLS_ERR_SSL_WANT_WRITE (-3)
+#endif
+
+#ifndef MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE
 #define MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE (-4)
+#endif
 
 #define coap_security_create(socket_id, timer_id, handle, \
                              mode, send_cb, receive_cb, start_timer_cb, timer_status_cb) ((coap_security_t *) 0)


### PR DESCRIPTION
-Use guards around MBEDTLS macros.