### PR TITLE
Message transaction memory handling changes

### DIFF
--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -168,12 +168,9 @@ static uint8_t coap_tx_function(uint8_t *data_ptr, uint16_t data_len, sn_nsdl_ad
         if (!transaction_ptr->data_ptr) {
             tr_debug("coap tx out of memory");
             return 0;
-
         }
         memcpy(transaction_ptr->data_ptr, data_ptr, data_len);
         transaction_ptr->data_len = data_len;
-    } else if (transaction_ptr->resp_cb == NULL ) {
-        transaction_delete(transaction_ptr);
     }
 
     return 0;


### PR DESCRIPTION
Changes to message transaction handling:
- when receiving request, parsed request message is freed after callback call,
not when sending response
- transaction is deleted when sending response