### PR TITLE
Delete transaction when not needed

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -88,7 +88,8 @@ typedef int coap_service_response_recv(int8_t service_id, uint8_t source_address
  * \param source_port        Source port.
  * \param request_ptr        Pointer to CoAP header structure.
  *
- * \return Status
+ * \return -1 = Message ignored, no response will be sent. Transaction will be deleted.
+ *          0 = Response is either already sent or will be send. Transaction is not deleted.
  */
 typedef int coap_service_request_recv_cb(int8_t service_id, uint8_t source_address[static 16], uint16_t source_port, sn_coap_hdr_s *request_ptr);
 

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -267,7 +267,10 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
                 memcpy(transaction_ptr->token, coap_message->token_ptr, coap_message->token_len);
             }
             transaction_ptr->remote_port = port;
-            cb(socket_id, coap_message, transaction_ptr);
+            if (cb(socket_id, coap_message, transaction_ptr) < 0) {
+                // negative return value = message ignored -> delete transaction
+                transaction_delete(transaction_ptr);
+            }
             goto exit;
         } else {
             ret_val = -1;

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -171,6 +171,8 @@ static uint8_t coap_tx_function(uint8_t *data_ptr, uint16_t data_len, sn_nsdl_ad
         }
         memcpy(transaction_ptr->data_ptr, data_ptr, data_len);
         transaction_ptr->data_len = data_len;
+    } else if (transaction_ptr->resp_cb == NULL ) {
+        transaction_delete(transaction_ptr);
     }
 
     return 0;


### PR DESCRIPTION
When response is not expected, transaction can be deleted after sending.
Transaction deleted depending on resource callback return value