### PR TITLE
Fix coap_connection_handler_send_data() return values

### DIFF
--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -283,6 +283,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
         }
         if (!this) {
             tr_error("client transaction not found");
+            ret_val = -1;
             goto exit;
         }
         tr_debug("Service %d, response received", this->service_id);
@@ -421,7 +422,9 @@ int8_t coap_message_handler_response_send(coap_msg_handler_t *handle, int8_t ser
 
     ret_val =  coap_message_handler_resp_build_and_send(handle, response, transaction_ptr);
     sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, response);
-    transaction_delete(transaction_ptr);
+    if(ret_val == 0) {
+        transaction_delete(transaction_ptr);
+    }
 
     return ret_val;
 }
@@ -458,8 +461,9 @@ int8_t coap_message_handler_response_send_by_msg_id(coap_msg_handler_t *handle, 
     }
 
     ret_val = coap_message_handler_resp_build_and_send(handle, &response, transaction_ptr);
-
-    transaction_delete(transaction_ptr);
+    if(ret_val == 0) {
+        transaction_delete(transaction_ptr);
+    }
 
     return ret_val;
 }

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -65,6 +65,11 @@ void connection_handler_close_secure_connection( coap_conn_handler_t *handler, u
 int coap_connection_handler_open_connection(coap_conn_handler_t *handler, uint16_t listen_port, bool use_ephemeral_port, bool is_secure, bool real_socket, bool bypassSec);
 
 //If returns -2, it means security was started and data was not send
+/*
+ * \return > 0 in OK
+ * \return 0 Session started, data not send
+ * \return -1 failure
+ */
 int coap_connection_handler_send_data(coap_conn_handler_t *handler, const ns_address_t *dest_addr, const uint8_t src_address[static 16], uint8_t *data_ptr, uint16_t data_len, bool bypass_link_sec);
 
 int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t address[static 16], uint16_t port, uint8_t *data_ptr, uint16_t data_len);

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -161,7 +161,7 @@ bool test_coap_connection_handler_send_data()
         return false;
 
     socket_api_stub.int8_value = 7;
-    if( 7 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
+    if( 1 != coap_connection_handler_send_data(handler, &addr, ns_in6addr_any, NULL, 0, true))
         return false;
     connection_handler_destroy(handler, false);
 

--- a/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
+++ b/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
@@ -119,6 +119,7 @@ bool test_coap_message_handler_coap_msg_process()
 {
     uint8_t buf[16];
     memset(&buf, 1, 16);
+    /*Handler is null*/
     if( -1 != coap_message_handler_coap_msg_process(NULL, 0, buf, 22, ns_in6addr_any, NULL, 0, NULL))
         return false;
 
@@ -128,12 +129,14 @@ bool test_coap_message_handler_coap_msg_process()
     coap_msg_handler_t *handle = coap_message_handler_init(&own_alloc, &own_free, &coap_tx_function);
 
     sn_coap_protocol_stub.expectedHeader = NULL;
+    /* Coap parse returns null */
     if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_protocol_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_protocol_stub.expectedHeader->coap_status = 66;
+    /* Coap library responds */
     if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
@@ -142,12 +145,17 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->coap_status = COAP_STATUS_OK;
     sn_coap_protocol_stub.expectedHeader->msg_code = 1;
     retValue = 0;
+    /* request received */
     if( 0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
+    sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_protocol_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_protocol_stub.expectedHeader->coap_status = COAP_STATUS_OK;
+    sn_coap_protocol_stub.expectedHeader->msg_code = 1;
     nsdynmemlib_stub.returnCounter = 1;
     retValue = -1;
-    if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( 0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -310,7 +318,7 @@ bool test_coap_message_handler_response_send()
     if( 0 != coap_message_handler_response_send(handle, 2, 0, header, 1,3,NULL, 0))
         return false;
 
-//    free(header);
+    free(header);
     free(sn_coap_protocol_stub.expectedCoap);
     sn_coap_protocol_stub.expectedCoap = NULL;
     coap_message_handler_destroy(handle);


### PR DESCRIPTION
Before, in some error cases coap_connection_handler_send_data() returned value
-2 that caused data pointer to be saved. That might leak memory, if data pointer
was already allocated.