### PR TITLE
Add check for interface when receiving CoAP request

### DIFF
--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -239,8 +239,8 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
     return transaction_find_by_address( address_ptr, port );
 }
 
-int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                      uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
+int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t interface_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
+                                      uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *))
 {
     sn_nsdl_addr_s src_addr;
     sn_coap_hdr_s *coap_message;
@@ -285,7 +285,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
                 transaction_ptr->token_len = coap_message->token_len;
             }
             transaction_ptr->remote_port = port;
-            if (cb(socket_id, coap_message, transaction_ptr) < 0) {
+            if (cb(socket_id, interface_id, coap_message, transaction_ptr) < 0) {
                 // negative return value = message ignored -> delete transaction
                 transaction_delete(transaction_ptr);
             }

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -36,7 +36,7 @@
 #include "coap_message_handler.h"
 #include "mbed-coap/sn_coap_protocol.h"
 
-static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr);
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t interface_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr);
 
 typedef struct uri_registration {
     char *uri_ptr;
@@ -210,7 +210,7 @@ static void service_event_handler(arm_event_s *event)
     eventOS_event_timer_request((uint8_t)COAP_TICK_TIMER, ARM_LIB_SYSTEM_TIMER_EVENT, tasklet_id, 1000);
 }
 
-static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr)
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t interface_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr)
 {
     coap_service_t *this;
     if (!coap_message || !transaction_ptr) {
@@ -229,6 +229,11 @@ static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_m
         return -1;
     }
 
+    if ((interface_id != -1) && (this->interface_id != interface_id)) {
+        tr_debug("uri %.*s not registered to interface %d", coap_message->uri_path_len, coap_message->uri_path_ptr, interface_id);
+        return 0;
+    }
+
     uri_registration_t *uri_reg_ptr = uri_registration_find(this, coap_message->uri_path_ptr, coap_message->uri_path_len);
     if (uri_reg_ptr && uri_reg_ptr->request_recv_cb) {
         tr_debug("Service %d, call request recv cb uri %.*s", this->service_id, coap_message->uri_path_len, coap_message->uri_path_ptr);
@@ -244,7 +249,7 @@ static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_m
     return -1;
 }
 
-static int recv_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len)
+static int recv_cb(int8_t socket_id, int8_t interface_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len)
 {
     uint8_t *data_ptr = NULL;
     uint16_t data_len = 0;
@@ -263,7 +268,7 @@ static int recv_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t po
     tr_debug("service recv socket data len %d ", data_len);
 
     //parse coap message what CoAP to use
-    int ret = coap_message_handler_coap_msg_process(coap_service_handle, socket_id, src_address, port, dst_address, data_ptr, data_len, &coap_msg_process_callback);
+    int ret = coap_message_handler_coap_msg_process(coap_service_handle, socket_id, interface_id, src_address, port, dst_address, data_ptr, data_len, &coap_msg_process_callback);
     own_free(data_ptr);
     return ret;
 }

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -35,7 +35,7 @@
 struct internal_socket_s;
 
 typedef int send_to_socket_cb(int8_t socket_id, const uint8_t address[static 16], uint16_t port, const void *, int);
-typedef int receive_from_socket_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
+typedef int receive_from_socket_cb(int8_t socket_id, int8_t interface_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
 typedef int get_pw_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
 typedef void security_done_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
 

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -76,8 +76,8 @@ extern coap_transaction_t *coap_message_handler_transaction_valid(coap_transacti
 
 extern coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, uint16_t port);
 
-extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                                         uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *));
+extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t interface_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
+                                                         uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *));
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                                       uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,

--- a/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
+++ b/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
@@ -133,7 +133,7 @@ bool test_coap_message_handler_coap_msg_process()
     uint8_t buf[16];
     memset(&buf, 1, 16);
     /*Handler is null*/
-    if( -1 != coap_message_handler_coap_msg_process(NULL, 0, buf, 22, ns_in6addr_any, NULL, 0, NULL))
+    if( -1 != coap_message_handler_coap_msg_process(NULL, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, NULL))
         return false;
 
     retCounter = 1;
@@ -143,14 +143,14 @@ bool test_coap_message_handler_coap_msg_process()
 
     sn_coap_protocol_stub.expectedHeader = NULL;
     /* Coap parse returns null */
-    if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( -1 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_protocol_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_protocol_stub.expectedHeader->coap_status = 66;
     /* Coap library responds */
-    if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( -1 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -159,7 +159,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_code = 1;
     retValue = 0;
     /* request received */
-    if( 0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( 0 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -168,7 +168,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_code = 1;
     nsdynmemlib_stub.returnCounter = 1;
     retValue = -1;
-    if( 0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( 0 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -176,7 +176,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->coap_status = COAP_STATUS_OK;
     sn_coap_protocol_stub.expectedHeader->msg_code = 333;
 
-    if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( -1 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
     sn_coap_protocol_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -197,7 +197,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_id = 2;
 //    sn_coap_protocol_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
 //    memset(sn_coap_protocol_stub.expectedHeader->token_ptr, 1, 4);
-    if( -1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
+    if( -1 != coap_message_handler_coap_msg_process(handle, 0, -1, buf, 22, ns_in6addr_any, NULL, 0, process_cb))
         return false;
 
 //    free(sn_coap_protocol_stub.expectedHeader->token_ptr);

--- a/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
+++ b/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
@@ -117,3 +117,9 @@ TEST(coap_service_api, test_coap_service_handshake_limit_set)
 {
     CHECK(test_coap_service_handshake_limit_set())
 }
+
+TEST(coap_service_api, test_coap_service_secure_session_close)
+{
+    CHECK(test_coap_service_secure_session_close())
+}
+

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
@@ -352,14 +352,14 @@ bool test_conn_handler_callbacks()
 
     if( thread_conn_handler_stub.receive_from_sock_cb ){
         coap_message_handler_stub.int16_value = 2;
-        if( -1 != thread_conn_handler_stub.receive_from_sock_cb(1, buf, 12, NULL, NULL, 0))
+        if( -1 != thread_conn_handler_stub.receive_from_sock_cb(1, -1, buf, 12, NULL, NULL, 0))
             return false;
 
         nsdynmemlib_stub.returnCounter = 1;
         uint8_t * ptr = ns_dyn_mem_alloc(5);
         memset(ptr, 3, 5);
         nsdynmemlib_stub.returnCounter = 1;
-        if( 2 != thread_conn_handler_stub.receive_from_sock_cb(1, buf, 12, NULL, ptr, 5))
+        if( 2 != thread_conn_handler_stub.receive_from_sock_cb(1, -1, buf, 12, NULL, ptr, 5))
             return false;
         ns_dyn_mem_free(ptr);
         coap_message_handler_stub.int16_value = 0;
@@ -367,7 +367,7 @@ bool test_conn_handler_callbacks()
         //This could be moved to own test function,
         //but thread_conn_handler_stub.receive_from_sock_cb must be called successfully
         if( coap_message_handler_stub.cb ){
-            if( -1 != coap_message_handler_stub.cb(1, NULL, NULL) )
+            if( -1 != coap_message_handler_stub.cb(1, -1, NULL, NULL) )
                 return false;
 
             sn_coap_hdr_s * coap = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -377,7 +377,7 @@ bool test_conn_handler_callbacks()
             coap->uri_path_ptr = &uri;
             coap->uri_path_len=2;
 
-            if( -1 != coap_message_handler_stub.cb(1, coap, NULL) )
+            if( -1 != coap_message_handler_stub.cb(1, -1, coap, NULL) )
                 return false;
 
             thread_conn_handler_stub.bool_value = true;
@@ -385,13 +385,13 @@ bool test_conn_handler_callbacks()
             if( 0 != coap_service_register_uri(1, "as", 1, &request_recv_cb) )
                 return false;
 
-            if( -1 != coap_message_handler_stub.cb(1, coap, NULL) )
+            if( -1 != coap_message_handler_stub.cb(1, -1, coap, NULL) )
                 return false;
 
             coap_transaction_t *tr = (coap_transaction_t *)malloc(sizeof(coap_transaction_t));
             memset(tr, 0, sizeof(coap_transaction_t));
 
-            if( 2 != coap_message_handler_stub.cb(1, coap, tr) )
+            if( 2 != coap_message_handler_stub.cb(1, -1, coap, tr) )
                 return false;
 
             free(tr);
@@ -588,4 +588,25 @@ bool test_coap_service_handshake_limit_set()
     }
 
     return true;
+}
+
+bool test_coap_service_secure_session_close()
+{
+    int service_id;
+    uint8_t addr_ptr[16] = {0};
+
+    thread_conn_handler_stub.handler_obj = (coap_conn_handler_t*)malloc(sizeof(coap_conn_handler_t));
+    memset(thread_conn_handler_stub.handler_obj, 0, sizeof(coap_conn_handler_t));
+
+    nsdynmemlib_stub.returnCounter = 1;
+    service_id = coap_service_initialize(1, 2, 0, NULL, NULL );
+
+    coap_service_close_secure_connection(0, NULL, 0);
+
+    coap_service_close_secure_connection(service_id, NULL, 0);
+
+    coap_service_close_secure_connection(service_id, addr_ptr, 1234);
+
+    coap_service_delete(service_id);
+    free(thread_conn_handler_stub.handler_obj);
 }

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
@@ -59,6 +59,8 @@ bool test_coap_service_if_find_by_socket();
 
 bool test_coap_service_handshake_limit_set();
 
+bool test_coap_service_secure_session_close();
+
 
 #ifdef __cplusplus
 }

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -33,7 +33,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
     return thread_conn_handler_stub.int_value;
 }
 
-coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
+coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, int8_t interface_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
                                                  int (*send_cb)(int8_t socket_id, uint8_t const address[static 16], uint16_t port, const void *, int),
                                                  int (*pw_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr),
                                                  void(*done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static KEY_BLOCK_LEN]) )

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.h
@@ -32,7 +32,7 @@ typedef struct {
     coap_conn_handler_t *handler_obj;
 
     int (*send_to_sock_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, const void *, int);
-    int (*receive_from_sock_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len);
+    int (*receive_from_sock_cb)(int8_t socket_id, int8_t interface_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len);
     int (*get_passwd_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
     void (*sec_done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
 

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -54,8 +54,8 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
     return coap_message_handler_stub.coap_tx_ptr;
 }
 
-int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                      uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
+int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t interface_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
+                                      uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *))
 {
     coap_message_handler_stub.cb = cb;
     return coap_message_handler_stub.int16_value;

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.h
@@ -31,7 +31,7 @@ typedef struct {
     uint16_t uint16_value;
     coap_msg_handler_t *coap_ptr;
     coap_transaction_t *coap_tx_ptr;
-    int16_t (*cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *);
+    int16_t (*cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *);
 } coap_message_handler_stub_def;
 
 extern coap_message_handler_stub_def coap_message_handler_stub;


### PR DESCRIPTION
Check that receive interface ID is matching to interface ID registered to URI.