### PR TITLE
Adjust request message validity lifetime

### DIFF
--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -389,7 +389,20 @@ uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t se
         transaction_delete(transaction_ptr);
         return 0;
     }
-    sn_coap_protocol_build(handle->coap, &dst_addr, data_ptr, &request, transaction_ptr);
+    int16_t sn_coap_ret = sn_coap_protocol_build(handle->coap, &dst_addr, data_ptr, &request, transaction_ptr);
+    if (sn_coap_ret == -4) {
+        /*
+         * Not able to add message to resend queue, adjust message lifetime to one resending
+         */
+        transaction_ptr->valid_until = coap_service_get_internal_timer_ticks() + COAP_RESENDING_INTERVAL;
+    } else if (sn_coap_ret < 0) {
+        /*
+         * Failed to build message, set transaction validity time to minimum to get this transaction cleared
+         * immediately and callback called.
+         */
+        transaction_ptr->valid_until = coap_service_get_internal_timer_ticks();
+    }
+
     transaction_ptr->msg_id = request.msg_id;
     handle->sn_coap_tx_callback(data_ptr, data_len, &dst_addr, transaction_ptr);
 

--- a/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
+++ b/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
@@ -252,6 +252,36 @@ bool test_coap_message_handler_request_send()
     if( 2 != coap_message_handler_request_send(handle, 3, 0, buf, 24, 1, 2, &uri, 4, NULL, 0, &resp_recv))
         return false;
 
+    /* Clear all transactions */
+    if( 0 != coap_message_handler_exec(handle, 0xffffffff))
+        return false;
+
+    sn_coap_protocol_stub.expectedInt16 = -4;
+    nsdynmemlib_stub.returnCounter = 3;
+    if( 2 != coap_message_handler_request_send(handle, 3, 0, buf, 24, 1, 2, &uri, 4, NULL, 0, &transaction_recv_cb))
+        return false;
+
+    transaction_cb = 0;
+    sn_coap_protocol_stub.expectedInt8 = 0;
+    if( 0 != coap_message_handler_exec(handle, 12))
+        return false;
+
+    if (transaction_cb != 1)
+        return false;
+
+    sn_coap_protocol_stub.expectedInt16 = -2;
+    nsdynmemlib_stub.returnCounter = 3;
+    if( 2 != coap_message_handler_request_send(handle, 3, 0, buf, 24, 1, 2, &uri, 4, NULL, 0, &transaction_recv_cb))
+        return false;
+
+    transaction_cb = 0;
+    if( 0 != coap_message_handler_exec(handle, 2)) {
+        return false;
+    }
+    if (transaction_cb != 1)
+        return false;
+
+
     free(sn_coap_protocol_stub.expectedCoap);
     sn_coap_protocol_stub.expectedCoap = NULL;
     coap_message_handler_destroy(handle);


### PR DESCRIPTION
Some applications need to wait for COAP response before they can
continue. The COAP response timeout could be shortened when remote
device is not sending the response.

Adjust request message lifetime based on sn_coap_protocol message
builder return value.