### PR TITLE
Session cleanup timer fixes

### DIFF
--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -1001,7 +1001,7 @@ void coap_connection_handler_exec(uint32_t time)
 {
     if(ns_list_count(&secure_session_list)){
         // Seek & destroy old sessions where close notify have been sent
-        ns_list_foreach(secure_session_t, cur_ptr, &secure_session_list) {
+        ns_list_foreach_safe(secure_session_t, cur_ptr, &secure_session_list) {
             if(cur_ptr->session_state == SECURE_SESSION_CLOSED) {
                 if((cur_ptr->last_contact_time +  CLOSED_SECURE_SESSION_TIMEOUT) <= time){
                     secure_session_delete(cur_ptr);

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -201,9 +201,10 @@ static void service_event_handler(arm_event_s *event)
         tr_debug("service tasklet initialised");
         /*initialize coap service and listen socket*/
     }
+
     if (event->event_type == ARM_LIB_SYSTEM_TIMER_EVENT && event->event_id == COAP_TICK_TIMER) {
         coap_message_handler_exec(coap_service_handle, coap_ticks++);
-        if(coap_ticks && !coap_ticks % SECURE_SESSION_CLEAN_INTERVAL){
+        if(coap_ticks && !(coap_ticks % SECURE_SESSION_CLEAN_INTERVAL)){
             coap_connection_handler_exec(coap_ticks);
         }
     }


### PR DESCRIPTION
Fixed session cleanup timer bugs:
- secure session exec interval operator logic fixed
- changed ns_list_foreach to ns_list_foreach_safe in session delete loop