### PR TITLE
Add API to set callback for CoAP msg prevalidation

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -121,6 +121,25 @@ typedef int coap_service_security_start_cb(int8_t service_id, uint8_t address[st
 typedef int coap_service_security_done_cb(int8_t service_id, uint8_t address[static 16], uint8_t keyblock[static 40]);
 
 /**
+ * \brief Address scope reading callback
+ *
+ * Address scope reading callback function type used in method coap_service_address_scope_read_function_set.
+ *
+ * \param interface_id       Application interface ID.
+ * \param address            Address to check scope.
+ *
+ * \return 1 if address scope is interface local,
+ *         2 if address scope is link local,
+ *         3 if address scope is realm local,
+ *         4 if address scope is admin local,
+ *         5 if address scope is site local,
+ *         6 if address scope is organization local,
+ *         7 if address scope is global,*
+ *         <0 in case of errors.
+ */
+typedef int coap_service_addr_scope_read_cb(int8_t interface_id, uint8_t address[static 16]);
+
+/**
  * \brief Initialise server instance.
  *
  * Initialise Thread services for the registered application.
@@ -131,7 +150,7 @@ typedef int coap_service_security_done_cb(int8_t service_id, uint8_t address[sta
  * \param *start_ptr         Callback to inform security handling is started and to fetch device password.
  * \param *coap_security_done_cb  Callback to inform security handling is done.
  *
- *  \return service_id / -1 for failure
+ * \return service_id / -1 for failure
  */
 extern int8_t coap_service_initialize(int8_t interface_id, uint16_t listen_port, uint8_t service_options, coap_service_security_start_cb *start_ptr, coap_service_security_done_cb *coap_security_done_cb);
 
@@ -373,6 +392,23 @@ extern int8_t coap_service_certificate_set(int8_t service_id, const unsigned cha
  *-         0              For success
  */
 extern int8_t coap_service_blockwise_size_set(int8_t service_id, uint16_t size);
+
+/**
+ * \brief Set address scope reading function.
+ *
+ * Set address scope reading function for listen port used for the service.
+ *
+ * CoAP service will call this function to validate incoming CoAP request
+ * destination address scope.
+ *
+ * \param service_id        Id number of the current service.
+ * \param address_read_cb   Callback to be called when address scope is read.
+ *
+ * \return -1              For failure
+ *          0              For success
+ */
+extern int8_t coap_service_address_scope_read_function_set(int8_t service_id, coap_service_addr_scope_read_cb *address_read_cb);
+
 #ifdef __cplusplus
 }
 #endif

--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -121,23 +121,23 @@ typedef int coap_service_security_start_cb(int8_t service_id, uint8_t address[st
 typedef int coap_service_security_done_cb(int8_t service_id, uint8_t address[static 16], uint8_t keyblock[static 40]);
 
 /**
- * \brief Address scope reading callback
+ * \brief Message prevalidation callback
  *
- * Address scope reading callback function type used in method coap_service_address_scope_read_function_set.
+ * Message prevalidation callback function type used in method coap_service_msg_prevalidate_callback_set.
  *
- * \param interface_id       Application interface ID.
- * \param address            Address to check scope.
+ * \param interface_id      Application interface ID.
+ * \param source_address    Sender address.
+ * \param source_port       Sender port.
+ * \param local_address     Local address.
+ * \param local_port        Local port.
+ * \param request_uri       CoAP URI, NUL terminated.
  *
- * \return 1 if address scope is interface local,
- *         2 if address scope is link local,
- *         3 if address scope is realm local,
- *         4 if address scope is admin local,
- *         5 if address scope is site local,
- *         6 if address scope is organization local,
- *         7 if address scope is global,*
- *         <0 in case of errors.
+ * \return <0 in case of errors,
+ *         0 if message is valid to process further,
+ *         >0 if message should be dropped.
  */
-typedef int coap_service_addr_scope_read_cb(int8_t interface_id, uint8_t address[static 16]);
+
+typedef int coap_service_msg_prevalidate_cb(int8_t interface_id, uint8_t source_address[static 16], uint16_t source_port, uint8_t local_address[static 16], uint16_t local_port, char *request_uri);
 
 /**
  * \brief Initialise server instance.
@@ -394,20 +394,19 @@ extern int8_t coap_service_certificate_set(int8_t service_id, const unsigned cha
 extern int8_t coap_service_blockwise_size_set(int8_t service_id, uint16_t size);
 
 /**
- * \brief Set address scope reading function.
+ * \brief Set message prevalidation callback function.
  *
- * Set address scope reading function for listen port used for the service.
+ * Set message prevalidation callback function for the service. Callback will be called for all services using the same listen port.
  *
- * CoAP service will call this function to validate incoming CoAP request
- * destination address scope.
+ * CoAP service will call this function to allow application prevalidate incoming CoAP message before passing it to application.
  *
- * \param service_id        Id number of the current service.
- * \param address_read_cb   Callback to be called when address scope is read.
+ * \param service_id            Id number of the current service.
+ * \param msg_prevalidate_cb    Callback to be called to validate incoming message before pprocessing it.
  *
  * \return -1              For failure
  *          0              For success
  */
-extern int8_t coap_service_address_scope_read_function_set(int8_t service_id, coap_service_addr_scope_read_cb *address_read_cb);
+extern int8_t coap_service_msg_prevalidate_callback_set(int8_t service_id, coap_service_msg_prevalidate_cb *msg_prevalidate_cb);
 
 #ifdef __cplusplus
 }

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -36,7 +36,7 @@ typedef enum session_state_e {
 
 typedef struct internal_socket_s {
     coap_conn_handler_t *parent;
-    addr_scope_cb *addr_scope_check_cb;  // callback function to check address scope
+    cch_func_cb *cch_function_callback;  // callback function
 
     uint32_t timeout_min;
     uint32_t timeout_max;
@@ -1025,19 +1025,21 @@ void coap_connection_handler_exec(uint32_t time)
     }
 }
 
-int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func)
+int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *handler, cch_func_cb *function_callback)
 {
     if (!handler) {
         return -1;
     }
-    handler->socket->addr_scope_check_cb = addr_scope_cb_func;
+    handler->socket->cch_function_callback = function_callback;
     return 0;
 }
 
-addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler)
+cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_handler_t *handler, uint16_t *listen_socket_port)
 {
-    if (!handler) {
+    if (!handler || !listen_socket_port) {
         return NULL;
     }
-    return handler->socket->addr_scope_check_cb;
+
+    *listen_socket_port = handler->socket->listen_port;
+    return handler->socket->cch_function_callback;
 }

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -36,6 +36,7 @@ typedef enum session_state_e {
 
 typedef struct internal_socket_s {
     coap_conn_handler_t *parent;
+    addr_scope_cb *addr_scope_check_cb;  // callback function to check address scope
 
     uint32_t timeout_min;
     uint32_t timeout_max;
@@ -1022,4 +1023,21 @@ void coap_connection_handler_exec(uint32_t time)
             }
         }
     }
+}
+
+int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func)
+{
+    if (!handler) {
+        return -1;
+    }
+    handler->socket->addr_scope_check_cb = addr_scope_cb_func;
+    return 0;
+}
+
+addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler)
+{
+    if (!handler) {
+        return NULL;
+    }
+    return handler->socket->addr_scope_check_cb;
 }

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -294,7 +294,7 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
 }
 
 int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
+                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
 {
     sn_nsdl_addr_s src_addr;
     sn_coap_hdr_s *coap_message;
@@ -345,7 +345,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
             memcpy(transaction_ptr->token, coap_message->token_ptr, coap_message->token_len);
             transaction_ptr->token_len = coap_message->token_len;
         }
-        if (msg_process_callback(socket_id, coap_message, transaction_ptr) < 0) {
+        if (msg_process_callback(socket_id, coap_message, transaction_ptr, dst_addr_ptr) < 0) {
             // negative return value = message ignored -> delete transaction
             transaction_delete(transaction_ptr);
         }

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -294,14 +294,14 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
 }
 
 int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
+                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
 {
     sn_nsdl_addr_s src_addr;
     sn_coap_hdr_s *coap_message;
     int16_t ret_val = 0;
     coap_transaction_t *this = NULL;
 
-    if (!cb || !handle) {
+    if (!msg_process_callback || !handle) {
         return -1;
     }
 
@@ -337,21 +337,21 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
         goto exit;
     }
 
-    /* Request received */
     if (coap_message->msg_code > 0 && coap_message->msg_code < 32) {
+        /* Request received */
         transaction_ptr->msg_id = coap_message->msg_id;
         transaction_ptr->req_msg_type = coap_message->msg_type;
         if (coap_message->token_len) {
             memcpy(transaction_ptr->token, coap_message->token_ptr, coap_message->token_len);
             transaction_ptr->token_len = coap_message->token_len;
         }
-        if (cb(socket_id, coap_message, transaction_ptr) < 0) {
+        if (msg_process_callback(socket_id, coap_message, transaction_ptr) < 0) {
             // negative return value = message ignored -> delete transaction
             transaction_delete(transaction_ptr);
         }
         goto exit;
-        /* Response received */
     } else {
+        /* Response received */
         transaction_delete(transaction_ptr); // transaction_ptr not needed in response
         if (coap_message->token_ptr) {
             this = transaction_find_client_by_token(coap_message->token_ptr, coap_message->token_len, source_addr_ptr, port);

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -38,7 +38,7 @@ typedef int send_to_socket_cb(int8_t socket_id, const uint8_t address[static 16]
 typedef int receive_from_socket_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
 typedef int get_pw_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
 typedef void security_done_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
-typedef int addr_scope_cb(int8_t interface_id, uint8_t address[static 16]);
+typedef void cch_func_cb(void);
 
 typedef struct coap_conn_handler_s {
     struct internal_socket_s *socket;
@@ -82,8 +82,8 @@ int8_t coap_connection_handler_handshake_limits_set(uint8_t handshakes_limit, ui
 
 void coap_connection_handler_exec(uint32_t time);
 
-int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func);
+int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *handler, cch_func_cb *function_callback);
 
-addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler);
+cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_handler_t *handler, uint16_t *listen_socket_port);
 
 #endif

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -38,6 +38,7 @@ typedef int send_to_socket_cb(int8_t socket_id, const uint8_t address[static 16]
 typedef int receive_from_socket_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
 typedef int get_pw_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
 typedef void security_done_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
+typedef int addr_scope_cb(int8_t interface_id, uint8_t address[static 16]);
 
 typedef struct coap_conn_handler_s {
     struct internal_socket_s *socket;
@@ -80,5 +81,9 @@ int8_t coap_connection_handler_set_timeout(coap_conn_handler_t *handler, uint32_
 int8_t coap_connection_handler_handshake_limits_set(uint8_t handshakes_limit, uint8_t connections_limit);
 
 void coap_connection_handler_exec(uint32_t time);
+
+int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func);
+
+addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler);
 
 #endif

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -85,7 +85,7 @@ extern coap_transaction_t *coap_message_handler_transaction_valid(coap_transacti
 extern coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, uint16_t port);
 
 extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                                     uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *));
+                                                     uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *));
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                                   uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,

--- a/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
+++ b/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
@@ -71,3 +71,8 @@ TEST(coap_connection_handler, test_security_callbacks)
     CHECK(test_security_callbacks());
 }
 
+TEST(coap_connection_handler, test_address_scope_read_and_set)
+{
+    CHECK(test_address_scope_read_and_set());
+}
+

--- a/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
+++ b/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
@@ -71,8 +71,8 @@ TEST(coap_connection_handler, test_security_callbacks)
     CHECK(test_security_callbacks());
 }
 
-TEST(coap_connection_handler, test_address_scope_read_and_set)
+TEST(coap_connection_handler, test_coap_connection_handler_msg_prevalidate_cb_read_and_set)
 {
-    CHECK(test_address_scope_read_and_set());
+    CHECK(test_coap_connection_handler_msg_prevalidate_cb_read_and_set());
 }
 

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -512,7 +512,7 @@ bool test_security_callbacks()
     return true;
 }
 
-bool test_address_scope_read_and_set()
+bool test_coap_connection_handler_msg_prevalidate_cb_read_and_set()
 {
     coap_security_handler_stub.counter = -1;
 
@@ -525,19 +525,20 @@ bool test_address_scope_read_and_set()
         return false;
     }
 
-    if (-1 != coap_connection_handler_address_scope_callback_set(NULL, 1000)) {
+    if (-1 != coap_connection_handler_msg_prevalidate_callback_set(NULL, 1000)) {
         return false;
     }
 
-    if (0 != coap_connection_handler_address_scope_callback_set(handler, 1000)) {
+    if (0 != coap_connection_handler_msg_prevalidate_callback_set(handler, 1000)) {
         return false;
     }
 
-    if (NULL != coap_connection_handler_address_scope_callback_get(NULL)) {
+    uint16_t listen_socket_port;
+    if (NULL != coap_connection_handler_msg_prevalidate_callback_get(NULL, &listen_socket_port)) {
         return false;
     }
 
-    if (1000 != coap_connection_handler_address_scope_callback_get(handler)) {
+    if (1000 != coap_connection_handler_msg_prevalidate_callback_get(handler, &listen_socket_port)) {
         return false;
     }
 

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -511,3 +511,40 @@ bool test_security_callbacks()
     sckt_data = NULL;
     return true;
 }
+
+bool test_address_scope_read_and_set()
+{
+    coap_security_handler_stub.counter = -1;
+
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
+
+    nsdynmemlib_stub.returnCounter = 1;
+    coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
+    nsdynmemlib_stub.returnCounter = 2;
+    if (0 != coap_connection_handler_open_connection(handler, 22, false, true, true, false)) {
+        return false;
+    }
+
+    if (-1 != coap_connection_handler_address_scope_callback_set(NULL, 1000)) {
+        return false;
+    }
+
+    if (0 != coap_connection_handler_address_scope_callback_set(handler, 1000)) {
+        return false;
+    }
+
+    if (NULL != coap_connection_handler_address_scope_callback_get(NULL)) {
+        return false;
+    }
+
+    if (1000 != coap_connection_handler_address_scope_callback_get(handler)) {
+        return false;
+    }
+
+    connection_handler_destroy(handler, false);
+
+    free(coap_security_handler_stub.sec_obj);
+    coap_security_handler_stub.sec_obj = NULL;
+
+    return true;
+}

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
@@ -41,6 +41,8 @@ bool test_socket_api_callbacks();
 
 bool test_security_callbacks();
 
+bool test_address_scope_read_and_set();
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
@@ -41,7 +41,7 @@ bool test_socket_api_callbacks();
 
 bool test_security_callbacks();
 
-bool test_address_scope_read_and_set();
+bool test_coap_connection_handler_msg_prevalidate_cb_read_and_set();
 
 #ifdef __cplusplus
 }

--- a/test/coap-service/unittest/coap_service_api/Makefile
+++ b/test/coap-service/unittest/coap_service_api/Makefile
@@ -33,7 +33,8 @@ TEST_SRC_FILES = \
 	../stub/coap_connection_handler_stub.c \
 	../stub/coap_message_handler_stub.c \
 	../stub/common_functions_stub.c \
-	../stub/sn_coap_protocol_stub.c
+	../stub/sn_coap_protocol_stub.c \
+	../stub/socket_api_stub.c
 
 include ../MakefileWorker.mk
 

--- a/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
+++ b/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
@@ -121,8 +121,8 @@ TEST(coap_service_api, test_coap_service_handshake_limit_set)
     CHECK(test_coap_service_handshake_limit_set())
 }
 
-TEST(coap_service_api, test_coap_service_address_scope_read_set)
+TEST(coap_service_api, test_coap_service_msg_prevalidate_cb_read_and_set)
 {
-    CHECK(test_coap_service_address_scope_read_set())
+    CHECK(test_coap_service_msg_prevalidate_cb_read_and_set())
 }
 

--- a/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
+++ b/test/coap-service/unittest/coap_service_api/coap_service_apitest.cpp
@@ -120,3 +120,9 @@ TEST(coap_service_api, test_coap_service_handshake_limit_set)
 {
     CHECK(test_coap_service_handshake_limit_set())
 }
+
+TEST(coap_service_api, test_coap_service_address_scope_read_set)
+{
+    CHECK(test_coap_service_address_scope_read_set())
+}
+

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
@@ -45,6 +45,11 @@ int virtual_sock_send_cb(int8_t service_id, uint8_t destination_addr_ptr[static 
     return 2;
 }
 
+int addr_scope_read_cb(int8_t interface_id, uint8_t address[static 16])
+{
+    return 7;
+}
+
 bool test_coap_service_initialize()
 {
     if (-1 != coap_service_initialize(1, 2, 0, NULL, NULL)) {
@@ -439,6 +444,19 @@ bool test_conn_handler_callbacks()
 
             coap_transaction_t *tr = (coap_transaction_t *)malloc(sizeof(coap_transaction_t));
             memset(tr, 0, sizeof(coap_transaction_t));
+            tr->local_address[0] = 2;
+
+            if (0 != coap_service_address_scope_read_function_set(1, addr_scope_read_cb)) {
+                return false;
+            }
+
+            if (-1 != coap_message_handler_stub.cb(1, coap, tr)) {
+                return false;
+            }
+
+            if (0 != coap_service_address_scope_read_function_set(1, NULL)) {
+                return false;
+            }
 
             if (2 != coap_message_handler_stub.cb(1, coap, tr)) {
                 return false;
@@ -642,6 +660,39 @@ bool test_coap_service_handshake_limit_set()
     if (0 != coap_service_handshake_limits_set(2, 2)) {
         return false;
     }
+
+    return true;
+}
+
+bool test_coap_service_address_scope_read_set()
+{
+    /* No valid service ID - return failure */
+    if (0 == coap_service_address_scope_read_function_set(0, addr_scope_read_cb)) {
+        return false;
+    }
+
+    /* Init service */
+    thread_conn_handler_stub.handler_obj = (coap_conn_handler_t *)malloc(sizeof(coap_conn_handler_t));
+    memset(thread_conn_handler_stub.handler_obj, 0, sizeof(coap_conn_handler_t));
+
+    nsdynmemlib_stub.returnCounter = 1;
+    thread_conn_handler_stub.bool_value = 0;
+    if (1 != coap_service_initialize(1, 2, 0, NULL, NULL)) {
+        return false;
+    }
+
+    if (0 != coap_service_address_scope_read_function_set(1, addr_scope_read_cb)) {
+        return false;
+    }
+
+    if (0 != coap_service_address_scope_read_function_set(1, NULL)) {
+        return false;
+    }
+
+    /* Teardown */
+    coap_service_delete(1);
+    free(thread_conn_handler_stub.handler_obj);
+    thread_conn_handler_stub.handler_obj = NULL;
 
     return true;
 }

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
@@ -45,9 +45,9 @@ int virtual_sock_send_cb(int8_t service_id, uint8_t destination_addr_ptr[static 
     return 2;
 }
 
-int addr_scope_read_cb(int8_t interface_id, uint8_t address[static 16])
+int msg_prevalidate_cb(int8_t interface_id, uint8_t address[static 16])
 {
-    return 7;
+    return 1;
 }
 
 bool test_coap_service_initialize()
@@ -446,7 +446,7 @@ bool test_conn_handler_callbacks()
             memset(tr, 0, sizeof(coap_transaction_t));
             tr->local_address[0] = 2;
 
-            if (0 != coap_service_address_scope_read_function_set(1, addr_scope_read_cb)) {
+            if (0 != coap_service_msg_prevalidate_callback_set(1, msg_prevalidate_cb)) {
                 return false;
             }
 
@@ -454,7 +454,7 @@ bool test_conn_handler_callbacks()
                 return false;
             }
 
-            if (0 != coap_service_address_scope_read_function_set(1, NULL)) {
+            if (0 != coap_service_msg_prevalidate_callback_set(1, NULL)) {
                 return false;
             }
 
@@ -664,10 +664,10 @@ bool test_coap_service_handshake_limit_set()
     return true;
 }
 
-bool test_coap_service_address_scope_read_set()
+bool test_coap_service_msg_prevalidate_cb_read_and_set()
 {
     /* No valid service ID - return failure */
-    if (0 == coap_service_address_scope_read_function_set(0, addr_scope_read_cb)) {
+    if (0 == coap_service_msg_prevalidate_callback_set(0, msg_prevalidate_cb)) {
         return false;
     }
 
@@ -681,11 +681,11 @@ bool test_coap_service_address_scope_read_set()
         return false;
     }
 
-    if (0 != coap_service_address_scope_read_function_set(1, addr_scope_read_cb)) {
+    if (0 != coap_service_msg_prevalidate_callback_set(1, msg_prevalidate_cb)) {
         return false;
     }
 
-    if (0 != coap_service_address_scope_read_function_set(1, NULL)) {
+    if (0 != coap_service_msg_prevalidate_callback_set(1, NULL)) {
         return false;
     }
 

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
@@ -61,7 +61,7 @@ bool test_coap_service_if_find_by_socket();
 
 bool test_coap_service_handshake_limit_set();
 
-bool test_coap_service_address_scope_read_set();
+bool test_coap_service_msg_prevalidate_cb_read_and_set();
 
 
 #ifdef __cplusplus

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.h
@@ -61,6 +61,8 @@ bool test_coap_service_if_find_by_socket();
 
 bool test_coap_service_handshake_limit_set();
 
+bool test_coap_service_address_scope_read_set();
+
 
 #ifdef __cplusplus
 }

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -42,6 +42,7 @@ coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, 
     thread_conn_handler_stub.receive_from_sock_cb = recv_cb;
     thread_conn_handler_stub.get_passwd_cb = pw_cb;
     thread_conn_handler_stub.sec_done_cb = done_cb;
+    thread_conn_handler_stub.addr_scope_check_cb = NULL;
     return thread_conn_handler_stub.handler_obj;
 }
 
@@ -81,5 +82,15 @@ int8_t coap_connection_handler_handshake_limits_set(uint8_t handshakes_limit, ui
 
 void coap_connection_handler_exec(uint32_t time)
 {
+}
 
+int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func)
+{
+    thread_conn_handler_stub.addr_scope_check_cb = addr_scope_cb_func;
+    return 0;
+}
+
+addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler)
+{
+    return thread_conn_handler_stub.addr_scope_check_cb;
 }

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -42,7 +42,7 @@ coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, 
     thread_conn_handler_stub.receive_from_sock_cb = recv_cb;
     thread_conn_handler_stub.get_passwd_cb = pw_cb;
     thread_conn_handler_stub.sec_done_cb = done_cb;
-    thread_conn_handler_stub.addr_scope_check_cb = NULL;
+    thread_conn_handler_stub.cch_function_callback = NULL;
     return thread_conn_handler_stub.handler_obj;
 }
 
@@ -84,13 +84,15 @@ void coap_connection_handler_exec(uint32_t time)
 {
 }
 
-int coap_connection_handler_address_scope_callback_set(coap_conn_handler_t *handler, addr_scope_cb *addr_scope_cb_func)
+int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *handler, cch_func_cb *function_callback)
 {
-    thread_conn_handler_stub.addr_scope_check_cb = addr_scope_cb_func;
+    thread_conn_handler_stub.cch_function_callback = function_callback;
     return 0;
 }
 
-addr_scope_cb *coap_connection_handler_address_scope_callback_get(coap_conn_handler_t *handler)
+
+cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_handler_t *handler, uint16_t *listen_socket_port)
 {
-    return thread_conn_handler_stub.addr_scope_check_cb;
+    *listen_socket_port = 0;
+    return thread_conn_handler_stub.cch_function_callback;
 }

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.h
@@ -30,6 +30,7 @@ typedef struct {
     int int_value;
     bool bool_value;
     coap_conn_handler_t *handler_obj;
+    addr_scope_cb *addr_scope_check_cb;
 
     int (*send_to_sock_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, const void *, int);
     int (*receive_from_sock_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len);

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.h
@@ -30,7 +30,7 @@ typedef struct {
     int int_value;
     bool bool_value;
     coap_conn_handler_t *handler_obj;
-    addr_scope_cb *addr_scope_check_cb;
+    cch_func_cb *cch_function_callback;
 
     int (*send_to_sock_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, const void *, int);
     int (*receive_from_sock_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len);

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -56,7 +56,7 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
 }
 
 int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *))
+                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
 {
     coap_message_handler_stub.cb = cb;
     return coap_message_handler_stub.int16_value;


### PR DESCRIPTION
Application can set message prevalidation callback method that can be used to validate incoming message before passing it further. 