### PR TITLE
Update message prevalidation API

### DIFF
--- a/coap-service/coap_service_api.h
+++ b/coap-service/coap_service_api.h
@@ -125,19 +125,20 @@ typedef int coap_service_security_done_cb(int8_t service_id, uint8_t address[sta
  *
  * Message prevalidation callback function type used in method coap_service_msg_prevalidate_callback_set.
  *
- * \param interface_id      Application interface ID.
- * \param source_address    Sender address.
- * \param source_port       Sender port.
- * \param local_address     Local address.
- * \param local_port        Local port.
- * \param request_uri       CoAP URI, NUL terminated.
+ * \param local_interface_id    Local interface ID, message arrived to this interface.
+ * \param local_address         Local address, message arrived to this address.
+ * \param local_port            Local port, message arrived to this port.
+ * \param recv_interface_id     Interface ID where message was received.
+ * \param source_address        Sender address.
+ * \param source_port           Sender port.
+ * \param coap_uri              CoAP URI, NUL terminated.
  *
  * \return <0 in case of errors,
  *         0 if message is valid to process further,
  *         >0 if message should be dropped.
  */
 
-typedef int coap_service_msg_prevalidate_cb(int8_t interface_id, uint8_t source_address[static 16], uint16_t source_port, uint8_t local_address[static 16], uint16_t local_port, char *request_uri);
+typedef int coap_service_msg_prevalidate_cb(int8_t local_interface_id, uint8_t local_address[static 16], uint16_t local_port, int8_t recv_interface_id, uint8_t source_address[static 16], uint16_t source_port, char *coap_uri);
 
 /**
  * \brief Initialise server instance.
@@ -400,13 +401,13 @@ extern int8_t coap_service_blockwise_size_set(int8_t service_id, uint16_t size);
  *
  * CoAP service will call this function to allow application prevalidate incoming CoAP message before passing it to application.
  *
- * \param service_id            Id number of the current service.
- * \param msg_prevalidate_cb    Callback to be called to validate incoming message before pprocessing it.
+ * \param listen_port           Socket port where to set callback.
+ * \param msg_prevalidate_cb    Callback to be called to validate incoming message before processing it. Use NULL to clear callback usage.
  *
  * \return -1              For failure
  *          0              For success
  */
-extern int8_t coap_service_msg_prevalidate_callback_set(int8_t service_id, coap_service_msg_prevalidate_cb *msg_prevalidate_cb);
+extern int8_t coap_service_msg_prevalidate_callback_set(uint16_t listen_port, coap_service_msg_prevalidate_cb *msg_prevalidate_cb);
 
 #ifdef __cplusplus
 }

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -45,6 +45,7 @@ typedef struct internal_socket_s {
 
     int16_t data_len;
     uint8_t *data;
+    int8_t recv_if_id;    // interface ID where data is coming from
 
     int8_t socket;  //positive value = socket id, negative value virtual socket id
     bool real_socket;
@@ -549,6 +550,7 @@ static int timer_status(int8_t timer_id)
 static int read_data(socket_callback_t *sckt_data, internal_socket_t *sock, ns_address_t *src_address, uint8_t dst_address[static 16])
 {
     sock->data_len = 0;
+    sock->recv_if_id = -1;
     if (sckt_data->event_type == SOCKET_DATA && sckt_data->d_len > 0) {
         uint8_t ancillary_databuffer[NS_CMSG_SPACE(sizeof(ns_in6_pktinfo_t))];
         ns_iovec_t msg_iov;
@@ -593,6 +595,7 @@ static int read_data(socket_callback_t *sckt_data, internal_socket_t *sock, ns_a
             }
             if (pkt) {
                 memcpy(dst_address, pkt->ipi6_addr, 16);
+                sock->recv_if_id = pkt->ipi6_ifindex;
             } else {
                 goto return_failure;
             }
@@ -694,7 +697,7 @@ static void secure_recv_sckt_msg(void *cb_res)
                     ns_dyn_mem_free(data);
                 } else {
                     if (sock->parent->_recv_cb) {
-                        sock->parent->_recv_cb(sock->socket, src_address.address, src_address.identifier, dst_address, data, len);
+                        sock->parent->_recv_cb(sock->socket, sock->recv_if_id, src_address.address, src_address.identifier, dst_address, data, len);
                     }
                     ns_dyn_mem_free(data);
                 }
@@ -713,7 +716,7 @@ static void recv_sckt_msg(void *cb_res)
 
     if (sock && read_data(sckt_data, sock, &src_address, dst_address) == 0) {
         if (sock->parent && sock->parent->_recv_cb) {
-            sock->parent->_recv_cb(sock->socket, src_address.address, src_address.identifier, dst_address, sock->data, sock->data_len);
+            sock->parent->_recv_cb(sock->socket, sock->recv_if_id, src_address.address, src_address.identifier, dst_address, sock->data, sock->data_len);
         }
         ns_dyn_mem_free(sock->data);
         sock->data = NULL;
@@ -802,7 +805,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
                     return 0;
                 } else {
                     if (sock->parent->_recv_cb) {
-                        sock->parent->_recv_cb(sock->socket, address, port, ns_in6addr_any, data, len);
+                        sock->parent->_recv_cb(sock->socket, sock->recv_if_id, address, port, ns_in6addr_any, data, len);
                     }
                     ns_dyn_mem_free(data);
                     data = NULL;
@@ -813,7 +816,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
     } else {
         /* unsecure*/
         if (sock->parent->_recv_cb) {
-            sock->parent->_recv_cb(sock->socket, address, port, ns_in6addr_any, sock->data, sock->data_len);
+            sock->parent->_recv_cb(sock->socket, sock->recv_if_id, address, port, ns_in6addr_any, sock->data, sock->data_len);
         }
         if (sock->data) {
             ns_dyn_mem_free(sock->data);
@@ -1032,6 +1035,16 @@ int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *ha
     }
     handler->socket->cch_function_callback = function_callback;
     return 0;
+}
+
+coap_conn_handler_t *coap_connection_handler_find_by_socket_port(uint16_t listen_port)
+{
+     ns_list_foreach(internal_socket_t, cur_ptr, &socket_list) {
+         if (cur_ptr->listen_port == listen_port) {
+             return cur_ptr->parent;
+         }
+     }
+     return NULL;
 }
 
 cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_handler_t *handler, uint16_t *listen_socket_port)

--- a/source/coap_connection_handler.c
+++ b/source/coap_connection_handler.c
@@ -1039,12 +1039,12 @@ int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *ha
 
 coap_conn_handler_t *coap_connection_handler_find_by_socket_port(uint16_t listen_port)
 {
-     ns_list_foreach(internal_socket_t, cur_ptr, &socket_list) {
-         if (cur_ptr->listen_port == listen_port) {
-             return cur_ptr->parent;
-         }
-     }
-     return NULL;
+    ns_list_foreach(internal_socket_t, cur_ptr, &socket_list) {
+        if (cur_ptr->listen_port == listen_port) {
+            return cur_ptr->parent;
+        }
+    }
+    return NULL;
 }
 
 cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_handler_t *handler, uint16_t *listen_socket_port)

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -294,7 +294,7 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
 }
 
 int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
+                                              uint8_t *data_ptr, uint16_t data_len,  coap_msg_process_cb *msg_process_callback)
 {
     sn_nsdl_addr_s src_addr;
     sn_coap_hdr_s *coap_message;

--- a/source/coap_message_handler.c
+++ b/source/coap_message_handler.c
@@ -293,8 +293,8 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
     return transaction_find_by_address(address_ptr, port);
 }
 
-int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
+int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
+                                              uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
 {
     sn_nsdl_addr_s src_addr;
     sn_coap_hdr_s *coap_message;
@@ -345,7 +345,7 @@ int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t
             memcpy(transaction_ptr->token, coap_message->token_ptr, coap_message->token_len);
             transaction_ptr->token_len = coap_message->token_len;
         }
-        if (msg_process_callback(socket_id, coap_message, transaction_ptr, dst_addr_ptr) < 0) {
+        if (msg_process_callback(socket_id, recv_if_id, coap_message, transaction_ptr, dst_addr_ptr) < 0) {
             // negative return value = message ignored -> delete transaction
             transaction_delete(transaction_ptr);
         }

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -36,7 +36,7 @@
 #include "coap_message_handler.h"
 #include "mbed-coap/sn_coap_protocol.h"
 
-static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr);
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr);
 
 typedef struct uri_registration {
     char *uri_ptr;
@@ -69,6 +69,13 @@ coap_msg_handler_t *coap_service_handle = NULL;
 static uint32_t coap_ticks = 1;
 
 #define COAP_TICK_TIMER 0xf1
+
+#define TRACE_DEEP
+#ifdef TRACE_DEEP
+#define tr_deep   tr_debug
+#else
+#define tr_deep(...)
+#endif
 
 static uri_registration_t *uri_registration_find(coap_service_t *this, const void *uri_ptr, uint16_t uri_len)
 {
@@ -165,7 +172,7 @@ static uint8_t coap_tx_function(uint8_t *data_ptr, uint16_t data_len, sn_nsdl_ad
         return 0;
     }
 
-    tr_debug("Service %d, CoAP TX Function - mid: %d", transaction_ptr->service_id, common_read_16_bit(data_ptr + 2));
+    tr_debug("Service %d, CoAP TX - mid: %d", transaction_ptr->service_id, common_read_16_bit(data_ptr + 2));
 
     this = service_find(transaction_ptr->service_id);
     if (!this) {
@@ -211,17 +218,44 @@ static void service_event_handler(arm_event_s *event)
     eventOS_event_timer_request((uint8_t)COAP_TICK_TIMER, ARM_LIB_SYSTEM_TIMER_EVENT, tasklet_id, 1000);
 }
 
-static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr)
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr)
 {
     coap_service_t *this;
+    coap_service_msg_prevalidate_cb *msg_prevalidate_callback;
+    uint16_t listen_socket_port;
+
     if (!coap_message || !transaction_ptr) {
         return -1;
     }
 
-    // Message is request, find correct handle
+    // Message is request, find correct handle based on URI
     this = service_find_by_uri(socket_id, coap_message->uri_path_ptr, coap_message->uri_path_len);
     if (!this) {
-        tr_debug("not registered uri %.*s", coap_message->uri_path_len, coap_message->uri_path_ptr);
+        tr_deep("URI %.*s not registered", coap_message->uri_path_len, coap_message->uri_path_ptr);
+        // URI is not available, find any service that holds the same shared socket so that we can get msg_prevalidate_callback to validate addresses
+        this = service_find_by_socket(socket_id);
+        if (!this) {
+            return -1;
+        }
+    }
+
+    msg_prevalidate_callback = (coap_service_msg_prevalidate_cb*)coap_connection_handler_msg_prevalidate_callback_get(this->conn_handler, &listen_socket_port);
+    if (msg_prevalidate_callback) {
+        // message prevalidation activated for the port
+        char request_uri[coap_message->uri_path_len + 1];
+        memcpy(request_uri, coap_message->uri_path_ptr, coap_message->uri_path_len);
+        request_uri[coap_message->uri_path_len] = 0;
+
+        int msg_prevalidate_status = msg_prevalidate_callback(this->interface_id, (uint8_t*)local_addr, listen_socket_port, recv_if_id, transaction_ptr->remote_address, transaction_ptr->remote_port, request_uri);
+        if (msg_prevalidate_status >= 1) {
+            tr_deep("Drop CoAP msg %s from %s to %s", request_uri, trace_ipv6(transaction_ptr->remote_address), trace_ipv6(local_addr));
+            return -1;
+        }
+    }
+
+    uri_registration_t *uri_reg_ptr = uri_registration_find(this, coap_message->uri_path_ptr, coap_message->uri_path_len);
+    if (!uri_reg_ptr) {
+        /* URI is not available, stop further processing */
         if (coap_message->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
             coap_message_handler_response_send(coap_service_handle, transaction_ptr->service_id, COAP_SERVICE_OPTIONS_NONE, coap_message,
                                                COAP_MSG_CODE_RESPONSE_NOT_FOUND, COAP_CT_NONE, NULL, 0);
@@ -230,40 +264,22 @@ static int16_t coap_msg_process_callback(int8_t socket_id, sn_coap_hdr_s *coap_m
         return -1;
     }
 
-    uri_registration_t *uri_reg_ptr = uri_registration_find(this, coap_message->uri_path_ptr, coap_message->uri_path_len);
-    if (uri_reg_ptr && uri_reg_ptr->request_recv_cb) {
-        tr_debug("Service %d, call request recv cb uri %.*s", this->service_id, coap_message->uri_path_len, coap_message->uri_path_ptr);
-
+    if (uri_reg_ptr->request_recv_cb) {
         if ((this->service_options & COAP_SERVICE_OPTIONS_SECURE_BYPASS) == COAP_SERVICE_OPTIONS_SECURE_BYPASS) { //TODO Add secure bypass option
             // Service has secure bypass active TODO this is not defined in interface
             // this check can be removed I think
             transaction_ptr->options = COAP_REQUEST_OPTIONS_SECURE_BYPASS;
         }
-        coap_service_msg_prevalidate_cb *msg_prevalidate_callback;
-        uint16_t listen_socket_port;
 
         transaction_ptr->service_id = this->service_id;
-
-        msg_prevalidate_callback = (coap_service_msg_prevalidate_cb*)coap_connection_handler_msg_prevalidate_callback_get(this->conn_handler, &listen_socket_port);
-        if (msg_prevalidate_callback) {
-            // message prevalidation activated for the port
-            char request_uri[coap_message->uri_path_len + 1];
-            memcpy(request_uri, coap_message->uri_path_ptr, coap_message->uri_path_len);
-            request_uri[coap_message->uri_path_len] = 0;
-
-            int msg_prevalidate_status = msg_prevalidate_callback(this->interface_id, transaction_ptr->remote_address, transaction_ptr->remote_port, (uint8_t*)local_addr, listen_socket_port, request_uri);
-            if (msg_prevalidate_status == 1) {
-                tr_warn("Drop msg %s", request_uri);
-                return -1;
-            }
-        }
-
+        tr_debug("Service %d, recv msg: %.*s", this->service_id, coap_message->uri_path_len, coap_message->uri_path_ptr);
         return uri_reg_ptr->request_recv_cb(this->service_id, transaction_ptr->remote_address, transaction_ptr->remote_port, coap_message);
     }
+
     return -1;
 }
 
-static int recv_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len)
+static int recv_cb(int8_t socket_id, int8_t recv_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len)
 {
     uint8_t *data_ptr = NULL;
     uint16_t data_len = 0;
@@ -279,10 +295,9 @@ static int recv_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t po
     }
     memcpy(data_ptr, data, len);
     data_len = len;
-    tr_debug("Service recv %d bytes", data_len);
 
     //parse coap message what CoAP to use
-    int ret = coap_message_handler_coap_msg_process(coap_service_handle, socket_id, src_address, port, dst_address, data_ptr, data_len, &coap_msg_process_callback);
+    int ret = coap_message_handler_coap_msg_process(coap_service_handle, socket_id, recv_if_id, src_address, port, dst_address, data_ptr, data_len, &coap_msg_process_callback);
     own_free(data_ptr);
     return ret;
 }
@@ -645,11 +660,11 @@ int8_t coap_service_blockwise_size_set(int8_t service_id, uint16_t size)
     return sn_coap_protocol_set_block_size(coap_service_handle->coap, size);
 }
 
-int8_t coap_service_msg_prevalidate_callback_set(int8_t service_id, coap_service_msg_prevalidate_cb *msg_prevalidate_cb)
+int8_t coap_service_msg_prevalidate_callback_set(uint16_t listen_socket, coap_service_msg_prevalidate_cb *msg_prevalidate_cb)
 {
-    coap_service_t *this = service_find(service_id);
-    if (this) {
-        return (int8_t)coap_connection_handler_msg_prevalidate_callback_set(this->conn_handler, (cch_func_cb*)msg_prevalidate_cb);
+    coap_conn_handler_t *conn_handler = coap_connection_handler_find_by_socket_port(listen_socket);
+    if (conn_handler) {
+        return (int8_t)coap_connection_handler_msg_prevalidate_callback_set(conn_handler, (cch_func_cb*)msg_prevalidate_cb);
     }
     return -1;
 }

--- a/source/coap_service_api.c
+++ b/source/coap_service_api.c
@@ -36,7 +36,7 @@
 #include "coap_message_handler.h"
 #include "mbed-coap/sn_coap_protocol.h"
 
-static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr);
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t *local_addr);
 
 typedef struct uri_registration {
     char *uri_ptr;
@@ -218,7 +218,7 @@ static void service_event_handler(arm_event_s *event)
     eventOS_event_timer_request((uint8_t)COAP_TICK_TIMER, ARM_LIB_SYSTEM_TIMER_EVENT, tasklet_id, 1000);
 }
 
-static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr)
+static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t *local_addr)
 {
     coap_service_t *this;
     coap_service_msg_prevalidate_cb *msg_prevalidate_callback;
@@ -239,14 +239,14 @@ static int16_t coap_msg_process_callback(int8_t socket_id, int8_t recv_if_id, sn
         }
     }
 
-    msg_prevalidate_callback = (coap_service_msg_prevalidate_cb*)coap_connection_handler_msg_prevalidate_callback_get(this->conn_handler, &listen_socket_port);
+    msg_prevalidate_callback = (coap_service_msg_prevalidate_cb *)coap_connection_handler_msg_prevalidate_callback_get(this->conn_handler, &listen_socket_port);
     if (msg_prevalidate_callback) {
         // message prevalidation activated for the port
         char request_uri[coap_message->uri_path_len + 1];
         memcpy(request_uri, coap_message->uri_path_ptr, coap_message->uri_path_len);
         request_uri[coap_message->uri_path_len] = 0;
 
-        int msg_prevalidate_status = msg_prevalidate_callback(this->interface_id, (uint8_t*)local_addr, listen_socket_port, recv_if_id, transaction_ptr->remote_address, transaction_ptr->remote_port, request_uri);
+        int msg_prevalidate_status = msg_prevalidate_callback(this->interface_id, (uint8_t *)local_addr, listen_socket_port, recv_if_id, transaction_ptr->remote_address, transaction_ptr->remote_port, request_uri);
         if (msg_prevalidate_status >= 1) {
             tr_deep("Drop CoAP msg %s from %s to %s", request_uri, trace_ipv6(transaction_ptr->remote_address), trace_ipv6(local_addr));
             return -1;
@@ -664,7 +664,7 @@ int8_t coap_service_msg_prevalidate_callback_set(uint16_t listen_socket, coap_se
 {
     coap_conn_handler_t *conn_handler = coap_connection_handler_find_by_socket_port(listen_socket);
     if (conn_handler) {
-        return (int8_t)coap_connection_handler_msg_prevalidate_callback_set(conn_handler, (cch_func_cb*)msg_prevalidate_cb);
+        return (int8_t)coap_connection_handler_msg_prevalidate_callback_set(conn_handler, (cch_func_cb *)msg_prevalidate_cb);
     }
     return -1;
 }

--- a/source/include/coap_connection_handler.h
+++ b/source/include/coap_connection_handler.h
@@ -35,7 +35,7 @@
 struct internal_socket_s;
 
 typedef int send_to_socket_cb(int8_t socket_id, const uint8_t address[static 16], uint16_t port, const void *, int);
-typedef int receive_from_socket_cb(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
+typedef int receive_from_socket_cb(int8_t socket_id, int8_t recv_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
 typedef int get_pw_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
 typedef void security_done_cb(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
 typedef void cch_func_cb(void);
@@ -81,6 +81,8 @@ int8_t coap_connection_handler_set_timeout(coap_conn_handler_t *handler, uint32_
 int8_t coap_connection_handler_handshake_limits_set(uint8_t handshakes_limit, uint8_t connections_limit);
 
 void coap_connection_handler_exec(uint32_t time);
+
+coap_conn_handler_t *coap_connection_handler_find_by_socket_port(uint16_t listen_port);
 
 int coap_connection_handler_msg_prevalidate_callback_set(coap_conn_handler_t *handler, cch_func_cb *function_callback);
 

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -85,7 +85,7 @@ typedef struct coap_transaction {
  *
  * \return 0 for success / -1 for failure
   */
-typedef int16_t coap_msg_process_cb(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr);
+typedef int16_t coap_msg_process_cb(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t *local_addr);
 
 extern coap_msg_handler_t *coap_message_handler_init(void *(*used_malloc_func_ptr)(uint16_t), void (*used_free_func_ptr)(void *),
                                                      uint8_t (*used_tx_callback_ptr)(uint8_t *, uint16_t, sn_nsdl_addr_s *, void *));
@@ -97,7 +97,7 @@ extern coap_transaction_t *coap_message_handler_transaction_valid(coap_transacti
 extern coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, uint16_t port);
 
 extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
-                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback);
+                                                     const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback);
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                                   uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -84,8 +84,9 @@ extern coap_transaction_t *coap_message_handler_transaction_valid(coap_transacti
 
 extern coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, uint16_t port);
 
-extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                                     uint8_t *data_ptr, uint16_t data_len, int16_t (msg_process_callback)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *));
+extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t source_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
+                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len,
+                                                    int16_t (msg_process_callback)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *));
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                                   uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,

--- a/source/include/coap_message_handler.h
+++ b/source/include/coap_message_handler.h
@@ -49,9 +49,7 @@ typedef int coap_message_handler_response_recv(int8_t service_id, uint8_t source
 typedef struct coap_msg_handler_s {
     void *(*sn_coap_service_malloc)(uint16_t);
     void (*sn_coap_service_free)(void *);
-
     uint8_t (*sn_coap_tx_callback)(uint8_t *, uint16_t, sn_nsdl_addr_s *, void *);
-
     struct coap_s *coap;
 } coap_msg_handler_t;
 
@@ -74,6 +72,20 @@ typedef struct coap_transaction {
     ns_list_link_t link;
 } coap_transaction_t;
 
+/**
+ * \brief Service message processing callback.
+ *
+ * Function that processes CoAP service message
+ *
+ * \param socket_id         Socket that receives the message.
+ * \param recv_if_id        Interface where message is received.
+ * \param coap_message      Actual CoAP message.
+ * \param transaction_ptr   Message transaction.
+ * \param local_addr        Address where message is received.
+ *
+ * \return 0 for success / -1 for failure
+  */
+typedef int16_t coap_msg_process_cb(int8_t socket_id, int8_t recv_if_id, sn_coap_hdr_s *coap_message, coap_transaction_t *transaction_ptr, const uint8_t * local_addr);
 
 extern coap_msg_handler_t *coap_message_handler_init(void *(*used_malloc_func_ptr)(uint16_t), void (*used_free_func_ptr)(void *),
                                                      uint8_t (*used_tx_callback_ptr)(uint8_t *, uint16_t, sn_nsdl_addr_s *, void *));
@@ -84,9 +96,8 @@ extern coap_transaction_t *coap_message_handler_transaction_valid(coap_transacti
 
 extern coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, uint16_t port);
 
-extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t source_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
-                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len,
-                                                    int16_t (msg_process_callback)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *));
+extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
+                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback);
 
 extern uint16_t coap_message_handler_request_send(coap_msg_handler_t *handle, int8_t service_id, uint8_t options, const uint8_t destination_addr[static 16],
                                                   uint16_t destination_port, sn_coap_msg_type_e msg_type, sn_coap_msg_code_e msg_code, const char *uri, sn_coap_content_format_e cont_type,

--- a/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
+++ b/test/coap-service/unittest/coap_connection_handler/coap_connection_handlertest.cpp
@@ -76,3 +76,8 @@ TEST(coap_connection_handler, test_coap_connection_handler_msg_prevalidate_cb_re
     CHECK(test_coap_connection_handler_msg_prevalidate_cb_read_and_set());
 }
 
+TEST(coap_connection_handler, test_coap_connection_handler_find_by_socket_port)
+{
+    CHECK(test_coap_connection_handler_find_by_socket_port());
+}
+

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -549,3 +549,37 @@ bool test_coap_connection_handler_msg_prevalidate_cb_read_and_set()
 
     return true;
 }
+
+bool test_coap_connection_handler_find_by_socket_port()
+{
+    coap_conn_handler_t *handler_ref;
+    coap_security_handler_stub.counter = -1;
+
+    coap_security_handler_stub.sec_obj = coap_security_handler_stub_alloc();
+
+    nsdynmemlib_stub.returnCounter = 1;
+    coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
+    nsdynmemlib_stub.returnCounter = 2;
+    if (0 != coap_connection_handler_open_connection(handler, 22, false, true, true, false)) {
+        return false;
+    }
+
+    handler_ref = coap_connection_handler_find_by_socket_port(1000);
+    if (NULL != handler_ref) {
+        return false;
+    }
+
+    handler_ref = coap_connection_handler_find_by_socket_port(22);
+    if (handler_ref->_recv_cb != receive_from_sock_cb) {
+        return false;
+    }
+
+    connection_handler_destroy(handler, false);
+
+    free(coap_security_handler_stub.sec_obj);
+    coap_security_handler_stub.sec_obj = NULL;
+
+    return true;
+}
+
+

--- a/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
+++ b/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.h
@@ -43,6 +43,8 @@ bool test_security_callbacks();
 
 bool test_coap_connection_handler_msg_prevalidate_cb_read_and_set();
 
+bool test_coap_connection_handler_find_by_socket_port();
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
+++ b/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
@@ -157,7 +157,7 @@ bool test_coap_message_handler_coap_msg_process()
     memset(&buf, 1, 16);
     bool ret_val = false;
     /*Handler is null*/
-    if (-1 != coap_message_handler_coap_msg_process(NULL, 0, buf, 22, ns_in6addr_any, NULL, 0, NULL)) {
+    if (-1 != coap_message_handler_coap_msg_process(NULL, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, NULL)) {
         goto exit;
     }
 
@@ -169,7 +169,7 @@ bool test_coap_message_handler_coap_msg_process()
 
     sn_coap_protocol_stub.expectedHeader = NULL;
     /* Coap parse returns null */
-    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (-1 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 
@@ -178,7 +178,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->coap_status = 66;
     nsdynmemlib_stub.returnCounter = 1;
     /* Coap library responds */
-    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (-1 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 
@@ -189,7 +189,7 @@ bool test_coap_message_handler_coap_msg_process()
     retValue = 0;
     /* request received */
     nsdynmemlib_stub.returnCounter = 1;
-    if (0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (0 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 
@@ -199,7 +199,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_code = 1;
     nsdynmemlib_stub.returnCounter = 1;
     retValue = -1;
-    if (0 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (0 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 
@@ -209,7 +209,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_code = 333;
     nsdynmemlib_stub.returnCounter = 1;
 
-    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 61131, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 
@@ -231,7 +231,7 @@ bool test_coap_message_handler_coap_msg_process()
 
     sn_coap_protocol_stub.expectedHeader->msg_id = 2;
 
-    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (-1 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
@@ -417,8 +417,8 @@ bool test_conn_handler_callbacks()
 
         //This could be moved to own test function,
         //but thread_conn_handler_stub.receive_from_sock_cb must be called successfully
-        if (coap_message_handler_stub.cb) {
-            if (-1 != coap_message_handler_stub.cb(1, 1, NULL, NULL, local_addr)) {
+        if (coap_message_handler_stub.msg_process_cb) {
+            if (-1 != coap_message_handler_stub.msg_process_cb(1, 1, NULL, NULL, local_addr)) {
                 return false;
             }
 
@@ -429,7 +429,7 @@ bool test_conn_handler_callbacks()
             coap->uri_path_ptr = &uri;
             coap->uri_path_len = 2;
 
-            if (-1 != coap_message_handler_stub.cb(1, 1, coap, NULL, local_addr)) {
+            if (-1 != coap_message_handler_stub.msg_process_cb(1, 1, coap, NULL, local_addr)) {
                 return false;
             }
 
@@ -439,7 +439,7 @@ bool test_conn_handler_callbacks()
                 return false;
             }
 
-            if (-1 != coap_message_handler_stub.cb(1, 1, coap, NULL, local_addr)) {
+            if (-1 != coap_message_handler_stub.msg_process_cb(1, 1, coap, NULL, local_addr)) {
                 return false;
             }
 
@@ -451,7 +451,7 @@ bool test_conn_handler_callbacks()
                 return false;
             }
 
-            if (-1 != coap_message_handler_stub.cb(1, 1, coap, tr, local_addr)) {
+            if (-1 != coap_message_handler_stub.msg_process_cb(1, 1, coap, tr, local_addr)) {
                 return false;
             }
 
@@ -459,7 +459,7 @@ bool test_conn_handler_callbacks()
                 return false;
             }
 
-            if (2 != coap_message_handler_stub.cb(1, 1, coap, tr, local_addr)) {
+            if (2 != coap_message_handler_stub.msg_process_cb(1, 1, coap, tr, local_addr)) {
                 return false;
             }
 

--- a/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
+++ b/test/coap-service/unittest/coap_service_api/test_coap_service_api.c
@@ -379,6 +379,7 @@ bool test_eventOS_callbacks()
 bool test_conn_handler_callbacks()
 {
     uint8_t buf[16];
+    uint8_t local_addr[16] = {0};
     thread_conn_handler_stub.handler_obj = (coap_conn_handler_t *)malloc(sizeof(coap_conn_handler_t));
     memset(thread_conn_handler_stub.handler_obj, 0, sizeof(coap_conn_handler_t));
     nsdynmemlib_stub.returnCounter = 1;
@@ -400,7 +401,7 @@ bool test_conn_handler_callbacks()
 
     if (thread_conn_handler_stub.receive_from_sock_cb) {
         coap_message_handler_stub.int16_value = 2;
-        if (-1 != thread_conn_handler_stub.receive_from_sock_cb(1, buf, 12, NULL, NULL, 0)) {
+        if (-1 != thread_conn_handler_stub.receive_from_sock_cb(1, 2, buf, 12, NULL, NULL, 0)) {
             return false;
         }
 
@@ -408,7 +409,7 @@ bool test_conn_handler_callbacks()
         uint8_t *ptr = ns_dyn_mem_alloc(5);
         memset(ptr, 3, 5);
         nsdynmemlib_stub.returnCounter = 1;
-        if (2 != thread_conn_handler_stub.receive_from_sock_cb(1, buf, 12, NULL, ptr, 5)) {
+        if (2 != thread_conn_handler_stub.receive_from_sock_cb(1, 2, buf, 12, NULL, ptr, 5)) {
             return false;
         }
         ns_dyn_mem_free(ptr);
@@ -417,7 +418,7 @@ bool test_conn_handler_callbacks()
         //This could be moved to own test function,
         //but thread_conn_handler_stub.receive_from_sock_cb must be called successfully
         if (coap_message_handler_stub.cb) {
-            if (-1 != coap_message_handler_stub.cb(1, NULL, NULL)) {
+            if (-1 != coap_message_handler_stub.cb(1, 1, NULL, NULL, local_addr)) {
                 return false;
             }
 
@@ -428,7 +429,7 @@ bool test_conn_handler_callbacks()
             coap->uri_path_ptr = &uri;
             coap->uri_path_len = 2;
 
-            if (-1 != coap_message_handler_stub.cb(1, coap, NULL)) {
+            if (-1 != coap_message_handler_stub.cb(1, 1, coap, NULL, local_addr)) {
                 return false;
             }
 
@@ -438,7 +439,7 @@ bool test_conn_handler_callbacks()
                 return false;
             }
 
-            if (-1 != coap_message_handler_stub.cb(1, coap, NULL)) {
+            if (-1 != coap_message_handler_stub.cb(1, 1, coap, NULL, local_addr)) {
                 return false;
             }
 
@@ -446,19 +447,19 @@ bool test_conn_handler_callbacks()
             memset(tr, 0, sizeof(coap_transaction_t));
             tr->local_address[0] = 2;
 
-            if (0 != coap_service_msg_prevalidate_callback_set(1, msg_prevalidate_cb)) {
+            if (0 != coap_service_msg_prevalidate_callback_set(2, msg_prevalidate_cb)) {
                 return false;
             }
 
-            if (-1 != coap_message_handler_stub.cb(1, coap, tr)) {
+            if (-1 != coap_message_handler_stub.cb(1, 1, coap, tr, local_addr)) {
                 return false;
             }
 
-            if (0 != coap_service_msg_prevalidate_callback_set(1, NULL)) {
+            if (0 != coap_service_msg_prevalidate_callback_set(2, NULL)) {
                 return false;
             }
 
-            if (2 != coap_message_handler_stub.cb(1, coap, tr)) {
+            if (2 != coap_message_handler_stub.cb(1, 1, coap, tr, local_addr)) {
                 return false;
             }
 
@@ -666,8 +667,8 @@ bool test_coap_service_handshake_limit_set()
 
 bool test_coap_service_msg_prevalidate_cb_read_and_set()
 {
-    /* No valid service ID - return failure */
-    if (0 == coap_service_msg_prevalidate_callback_set(0, msg_prevalidate_cb)) {
+    /* No valid socket port - return failure */
+    if (0 == coap_service_msg_prevalidate_callback_set(99, msg_prevalidate_cb)) {
         return false;
     }
 
@@ -681,11 +682,11 @@ bool test_coap_service_msg_prevalidate_cb_read_and_set()
         return false;
     }
 
-    if (0 != coap_service_msg_prevalidate_callback_set(1, msg_prevalidate_cb)) {
+    if (0 != coap_service_msg_prevalidate_callback_set(2, msg_prevalidate_cb)) {
         return false;
     }
 
-    if (0 != coap_service_msg_prevalidate_callback_set(1, NULL)) {
+    if (0 != coap_service_msg_prevalidate_callback_set(2, NULL)) {
         return false;
     }
 

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -33,7 +33,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
     return thread_conn_handler_stub.int_value;
 }
 
-coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, int8_t source_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
+coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, int8_t recv_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
                                                int (*send_cb)(int8_t socket_id, uint8_t const address[static 16], uint16_t port, const void *, int),
                                                int (*pw_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr),
                                                void(*done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static KEY_BLOCK_LEN]))

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.c
@@ -33,7 +33,7 @@ int coap_connection_handler_virtual_recv(coap_conn_handler_t *handler, uint8_t a
     return thread_conn_handler_stub.int_value;
 }
 
-coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
+coap_conn_handler_t *connection_handler_create(int (*recv_cb)(int8_t socket_id, int8_t source_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int),
                                                int (*send_cb)(int8_t socket_id, uint8_t const address[static 16], uint16_t port, const void *, int),
                                                int (*pw_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr),
                                                void(*done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static KEY_BLOCK_LEN]))
@@ -95,4 +95,9 @@ cch_func_cb *coap_connection_handler_msg_prevalidate_callback_get(coap_conn_hand
 {
     *listen_socket_port = 0;
     return thread_conn_handler_stub.cch_function_callback;
+}
+
+coap_conn_handler_t *coap_connection_handler_find_by_socket_port(uint16_t listen_port)
+{
+    return thread_conn_handler_stub.handler_obj;
 }

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.h
@@ -33,7 +33,7 @@ typedef struct {
     cch_func_cb *cch_function_callback;
 
     int (*send_to_sock_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, const void *, int);
-    int (*receive_from_sock_cb)(int8_t socket_id, int8_t source_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
+    int (*receive_from_sock_cb)(int8_t socket_id, int8_t recv_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
     int (*get_passwd_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
     void (*sec_done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
 

--- a/test/coap-service/unittest/stub/coap_connection_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_connection_handler_stub.h
@@ -33,7 +33,7 @@ typedef struct {
     cch_func_cb *cch_function_callback;
 
     int (*send_to_sock_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, const void *, int);
-    int (*receive_from_sock_cb)(int8_t socket_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *data, int len);
+    int (*receive_from_sock_cb)(int8_t socket_id, int8_t source_if_id, uint8_t src_address[static 16], uint16_t port, const uint8_t dst_address[static 16], unsigned char *, int);
     int (*get_passwd_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, coap_security_keys_t *security_ptr);
     void (*sec_done_cb)(int8_t socket_id, uint8_t address[static 16], uint16_t port, uint8_t keyblock[static 40]);
 

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -55,8 +55,8 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
     return coap_message_handler_stub.coap_tx_ptr;
 }
 
-int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
+int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t source_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
+                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
 {
     coap_message_handler_stub.cb = cb;
     return coap_message_handler_stub.int16_value;

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -56,7 +56,7 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
 }
 
 extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
-                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback)
+                                                     const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback)
 {
     coap_message_handler_stub.msg_process_cb = msg_process_callback;
     return coap_message_handler_stub.int16_value;

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.c
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.c
@@ -55,10 +55,10 @@ coap_transaction_t *coap_message_handler_find_transaction(uint8_t *address_ptr, 
     return coap_message_handler_stub.coap_tx_ptr;
 }
 
-int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t source_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port, const uint8_t dst_addr_ptr[static 16],
-                                              uint8_t *data_ptr, uint16_t data_len, int16_t (cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *))
+extern int16_t coap_message_handler_coap_msg_process(coap_msg_handler_t *handle, int8_t socket_id, int8_t recv_if_id, const uint8_t source_addr_ptr[static 16], uint16_t port,
+                                                    const uint8_t dst_addr_ptr[static 16], uint8_t *data_ptr, uint16_t data_len, coap_msg_process_cb *msg_process_callback)
 {
-    coap_message_handler_stub.cb = cb;
+    coap_message_handler_stub.msg_process_cb = msg_process_callback;
     return coap_message_handler_stub.int16_value;
 }
 

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.h
@@ -31,7 +31,7 @@ typedef struct {
     uint16_t uint16_value;
     coap_msg_handler_t *coap_ptr;
     coap_transaction_t *coap_tx_ptr;
-    int16_t (*cb)(int8_t, sn_coap_hdr_s *, coap_transaction_t *);
+    int16_t (*cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *);
 } coap_message_handler_stub_def;
 
 extern coap_message_handler_stub_def coap_message_handler_stub;

--- a/test/coap-service/unittest/stub/coap_message_handler_stub.h
+++ b/test/coap-service/unittest/stub/coap_message_handler_stub.h
@@ -31,7 +31,7 @@ typedef struct {
     uint16_t uint16_value;
     coap_msg_handler_t *coap_ptr;
     coap_transaction_t *coap_tx_ptr;
-    int16_t (*cb)(int8_t, int8_t, sn_coap_hdr_s *, coap_transaction_t *, const uint8_t *);
+    coap_msg_process_cb *msg_process_cb;
 } coap_message_handler_stub_def;
 
 extern coap_message_handler_stub_def coap_message_handler_stub;

--- a/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -59,12 +59,12 @@ void mbedtls_ssl_conf_max_version(mbedtls_ssl_config *conf, int major, int minor
 
 }
 
-void mbedtls_ssl_conf_transport( mbedtls_ssl_config *conf, int transport )
+void mbedtls_ssl_conf_transport(mbedtls_ssl_config *conf, int transport)
 {
 
 }
 
-void mbedtls_ssl_config_init( mbedtls_ssl_config *a )
+void mbedtls_ssl_config_init(mbedtls_ssl_config *a)
 {
 
 }
@@ -203,12 +203,12 @@ int mbedtls_ssl_write(mbedtls_ssl_context *a, const unsigned char *b, size_t c)
     return mbedtls_stub.expected_int;
 }
 
-int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
+int mbedtls_ssl_set_hostname(mbedtls_ssl_context *ssl, const char *hostname)
 {
     return 0;
 }
 
-const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ssl )
+const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert(const mbedtls_ssl_context *ssl)
 {
     return NULL;
 }
@@ -267,14 +267,14 @@ int mbedtls_x509_crt_parse(mbedtls_x509_crt *a, const unsigned char *b, size_t c
     return mbedtls_stub.expected_int;
 }
 
-int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
-                   const mbedtls_x509_crt *crt )
+int mbedtls_x509_crt_info(char *buf, size_t size, const char *prefix,
+                          const mbedtls_x509_crt *crt)
 {
     return 0;
 }
 
-int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
-                          uint32_t flags )
+int mbedtls_x509_crt_verify_info(char *buf, size_t size, const char *prefix,
+                                 uint32_t flags)
 {
     return 0;
 }
@@ -384,5 +384,6 @@ int mbedtls_ssl_session_reset(mbedtls_ssl_context *ssl)
     return mbedtls_stub.expected_int;
 }
 
-void mbedtls_strerror( int ret, char *buf, size_t buflen ){
+void mbedtls_strerror(int ret, char *buf, size_t buflen)
+{
 }


### PR DESCRIPTION
-Change prevalidation API to use socket listen port instead of service ID
-Add new internal method to find connection handler based on socket port
-Add receiving interface ID to callback API
-Reorder callback parameters
-Update function coap_message_handler_coap_msg_process signature

**Note**! This PR requires corresponding API changes to Nanostack
