### PR TITLE
Match COAP test stub to updated mbed-coap API

### DIFF
--- a/test/coap-service/unittest/MakefileWorker.mk
+++ b/test/coap-service/unittest/MakefileWorker.mk
@@ -544,7 +544,6 @@ endif
 	/usr/share/cpputest/scripts/filterGcov.sh $(GCOV_OUTPUT) $(GCOV_ERROR) $(GCOV_REPORT) $(TEST_OUTPUT)
 	$(SILENCE)cat $(GCOV_REPORT)
 	$(SILENCE)mkdir -p gcov
-	$(SILENCE)mv *.gcov gcov
 	$(SILENCE)mv gcov_* gcov
 	@echo "See gcov directory for details"
 

--- a/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
+++ b/test/coap-service/unittest/coap_message_handler/test_coap_message_handler.c
@@ -209,7 +209,7 @@ bool test_coap_message_handler_coap_msg_process()
     sn_coap_protocol_stub.expectedHeader->msg_code = 333;
     nsdynmemlib_stub.returnCounter = 1;
 
-    if (-1 != coap_message_handler_coap_msg_process(handle, 0, buf, 61131, 22, ns_in6addr_any, NULL, 0, process_cb)) {
+    if (-1 != coap_message_handler_coap_msg_process(handle, 0, 61131, buf, 22, ns_in6addr_any, NULL, 0, process_cb)) {
         goto exit;
     }
 

--- a/test/coap-service/unittest/stub/sn_coap_builder_stub.c
+++ b/test/coap-service/unittest/stub/sn_coap_builder_stub.c
@@ -34,22 +34,22 @@
 
 sn_coap_builder_stub_def sn_coap_builder_stub;
 
-sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
+sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, const sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
 {
     return sn_coap_builder_stub.expectedHeader;
 }
 
-int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr)
+int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     return sn_coap_builder_stub.expectedInt16;
 }
 
-uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr)
+uint16_t sn_coap_builder_calc_needed_packet_data_size(const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     return sn_coap_builder_stub.expectedUint16;
 }
 
-uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size)
+uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size)
 {
     return sn_coap_builder_stub.expectedUint16;
 }


### PR DESCRIPTION
-Change updated COAP APIs to sn_coap_builder_stub
-Fix message_handler test